### PR TITLE
feat(parser): add command list conversion utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SRCS     = \
   $(SRC_DIR)/parser/parser_init.c \
   $(SRC_DIR)/parser/parser_free.c \
   $(SRC_DIR)/parser/parser_parse.c \
+  $(SRC_DIR)/parser/parser_to_list.c \
   \
   $(SRC_DIR)/reader/reader_free.c \
   $(SRC_DIR)/reader/reader_init.c \

--- a/src/parser/parser_to_list.c
+++ b/src/parser/parser_to_list.c
@@ -1,0 +1,56 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_to_list.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/19 15:38:30 by lfiorell@st       #+#    #+#             */
+/*   Updated: 2025/06/19 15:40:55 by lfiorell@st      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "parser.h"
+#include <errno.h>
+
+t_cmd	*parser_to_list(t_parser *parser)
+{
+	size_t	len;
+	size_t	i;
+	t_cmd	*commands;
+	t_list	*current;
+
+	if (parser == NULL || parser->command_list == NULL)
+	{
+		errno = EINVAL;
+		return (NULL);
+	}
+	len = ft_lstsize(parser->command_list);
+	if (len == 0)
+	{
+		errno = EINVAL;
+		return (NULL);
+	}
+	commands = ft_calloc(len, sizeof(t_cmd));
+	if (commands == NULL)
+	{
+		errno = ENOMEM;
+		return (NULL);
+	}
+	i = 0;
+	current = parser->command_list;
+	while (current && i < len)
+	{
+		commands[i] = *(t_cmd *)current->content;
+		current = current->next;
+		i++;
+	}
+	if (i < len)
+	{
+		free(commands);
+		errno = EINVAL;
+		return (NULL);
+	}
+	return (commands);
+}

--- a/src/reader/handle_read.c
+++ b/src/reader/handle_read.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/17 10:58:53 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/06/19 11:09:15 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/06/19 15:35:44 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,6 +82,19 @@ bool	try_parse(t_reader *reader)
 	return (true);
 }
 
+bool	str_is_whitespace(const char *str)
+{
+	if (str == NULL)
+		return (false);
+	while (*str)
+	{
+		if (!ft_ciswhite(*str))
+			return (false);
+		str++;
+	}
+	return (true);
+}
+
 void	handle_read(t_reader *reader, const char *input)
 {
 	if (reader == NULL || input == NULL)
@@ -92,6 +105,13 @@ void	handle_read(t_reader *reader, const char *input)
 	if (!try_read(reader, input))
 	{
 		errno = ENOMEM;
+		return ;
+	}
+	// if it only contains whitespace, we can skip lexing and parsing
+	if (str_is_whitespace(reader->cached))
+	{
+		free(reader->cached);
+		reader->cached = NULL;
 		return ;
 	}
 	if (!try_lex(reader))
@@ -109,7 +129,8 @@ void	handle_read(t_reader *reader, const char *input)
 		reader->lexer = NULL;
 		if (reader->tokens)
 		{
-//			ft_lstclear(&reader->tokens, (void (*)(void *))free_token);
+			//			ft_lstclear(&reader->tokens,
+			//			(void (*)(void *))free_token);
 			reader->tokens = NULL;
 		}
 		errno = EINVAL;


### PR DESCRIPTION
• Add **parser_to_list()** function to convert linked list to array format • Implement robust error handling with proper  validation • Enable efficient command processing in `t_cmd` array structure • Update **Makefile** to include new `parser_to_list.c` source file • Enhance **reader** with whitespace-only input validation via `str_is_whitespace()` • Prevent unnecessary lexing/parsing of empty or whitespace-only commands

Components affected: **parser**, **reader**, **build system**