### PR TITLE
refactor(utils): simplify env entry formatting in b_getenv

### DIFF
--- a/src/utils/b_getenv.c
+++ b/src/utils/b_getenv.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/05 11:00:00 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/06/27 19:01:33 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/01 16:29:54 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,57 +28,25 @@ static int	str_equal(const char *s1, const char *s2)
 	return (ft_strncmp(s1, s2, len1) == 0);
 }
 
-static char	*ft_strjoin_free(char *s1, char *s2, int free_s1)
-{
-	char	*result;
-	size_t	len1;
-	size_t	len2;
-
-	if (!s1 && !s2)
-		return (NULL);
-	if (!s1)
-	{
-		result = ft_strdup(s2);
-		free(s2);
-	}
-	else if (!s2)
-	{
-		result = ft_strdup(s1);
-		free(s1);
-	}
-	else
-	{
-		len1 = ft_strlen(s1);
-		len2 = ft_strlen(s2);
-		result = ft_calloc(len1 + len2 + 1, sizeof(char));
-		if (!result)
-		{
-			free(s1);
-			free(s2);
-			return (NULL);
-		}
-		ft_strlcpy(result, s1, len1 + 1);
-		ft_strlcat(result, s2, len1 + len2 + 1);
-		if (free_s1)
-			free(s1);
-		free(s2);
-	}
-	return (result);
-}
-
 static char	*format_env_entry(t_env *env_entry)
 {
-	char	*temp;
 	char	*result;
+	size_t	key_len;
+	size_t	value_len;
 
+	key_len = ft_strlen(env_entry->key);
 	if (env_entry->value)
-	{
-		temp = ft_strjoin(env_entry->key, "=");
-		result = ft_strjoin_free(temp, env_entry->value, 1);
-		return (result);
-	}
+		value_len = ft_strlen(env_entry->value);
 	else
-		return (ft_strjoin(env_entry->key, "="));
+		value_len = 0;
+	result = malloc(key_len + value_len + 2); // +1 for '=', +1 for '\0'
+	if (!result)
+		return (NULL);
+	ft_strlcpy(result, env_entry->key, key_len + 1);
+	ft_strlcat(result, "=", key_len + 2);
+	if (env_entry->value)
+		ft_strlcat(result, env_entry->value, key_len + value_len + 2);
+	return (result);
 }
 
 static char	**get_all_env(t_list *envp)


### PR DESCRIPTION
• Remove custom `ft_strjoin_free` helper function (32 lines) • Replace with direct memory allocation using **malloc** and string ops • Use `ft_strlcpy` and `ft_strlcat` for safer string concatenation • Improve code readability and reduce function complexity • Maintain same functionality for environment variable formatting