### PR TITLE
chore(vscode): update file association for license files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(gdb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/minishell",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.associations": {
     "*.h": "c",
-    "*.topic": "html"
+    "*.topic": "html",
+    "*/licenses/*": "text"
   }
 }


### PR DESCRIPTION
This pull request introduces updates to the `.vscode` configuration files to enhance the development environment for the project. The most significant changes include the addition of a debug configuration for `gdb` and an update to file association settings.

### Debug Configuration Updates:
* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R32): Added a new debug configuration for `gdb`, enabling developers to launch and debug the `minishell` program directly within the VS Code environment. The configuration includes settings for pretty-printing and Intel disassembly flavor in `gdb`.

### File Association Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L4-R5): Updated file associations to treat files in the `licenses` directory as plain text, improving readability and editing experience for license files.