### PR TITLE
exit fork bugfix

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -69,7 +69,7 @@ typedef struct s_cmd
 	int		cmdnbr;
 	int		fd_infile;
 	int		fd_outfile;
-	int		**pipes; //-------------------TODO
+	int		**pipes;
 	int     fd[2];
 	char	**args;
 	char	**cmdpathlist;
@@ -81,14 +81,15 @@ typedef struct s_cmd
                                                       
 //pipex/ft_pipex.c                                    
 void	ft_pipex(t_cmd *cmd, t_list *tenvp);
-                                                      
+
 //pipex/cmd_path.c                                    
 void	ft_free_split(char **split);
-                                                      
+
 //pipex/ft_error.c                                    
 void	ft_cmdpathlist(t_cmd *cmd, t_list *tenvp);
 
 // pipex/ft_utils.c
+void    closefd(t_cmd *cmd, int exitnbr);
 int		ft_nbrofcmds(t_cmd *cmd);
 
 // base_commands/exit.c

--- a/src/base_commands/exit.c
+++ b/src/base_commands/exit.c
@@ -48,7 +48,7 @@ bool	isstring_noomber(char *s)
 
 void	ft_exit(char **s, t_reader *reader)
 {
-	int	exit_code;
+	unsigned char	exit_code;
 
 	if (!s || !*s)
 	{
@@ -69,11 +69,6 @@ void	ft_exit(char **s, t_reader *reader)
 	if (s[1])
 	{
 		exit_code = ft_atoi(s[1]);
-		if (exit_code < 0 || exit_code > 255)
-		{
-			ft_putstr_fd("exit: exit code out of range (0-255)\n", 2);
-			exit_code = 255; // Set to a default exit code
-		}
 	}
 	// Free the reader resources
 	if (reader)

--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -6,7 +6,7 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:03:33 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/03 13:42:49 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/04 14:52:49 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,49 +16,29 @@
 
 static void	fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx)
 {
-	t_iteration	iter;
-
 	cmd[cmd_idx].pid = fork();
 	if (cmd[cmd_idx].pid == -1)
 	{
 		printf("error fork of pid %d", cmd_idx);
-		return ; // TODO handle exit failure
+		closefd(cmd, EXIT_FAILURE); // TODO handle exit failure
 	}
 	if (cmd[cmd_idx].pid == 0)
 	{
-		if (!cmd->cmdpathlist[cmd_idx])
-			return ; // TODO handle exit failure
+		if (cmd->error == 1)
+			closefd(cmd, EXIT_FAILURE); // TODO exit failure free
 		/*
-		if (cmd_idx == 0)
-			dup2(cmd->fd_infile, STDIN_FILENO);
-		else
-			dup2(cmd->pipes[cmd_idx-1][0], STDIN_FILENO);
-		if (cmd_idx == cmd->cmdnbr - 1)
-			dup2(cmd->fd_outfile, STDOUT_FILENO);
-		else
-			dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
+		if (!cmd->cmdpathlist[cmd_idx])
+			return (closefd(cmd, exit)); // TODO handle exit failure
 		*/
-		/**/
-		// Set up stdin
 		if (cmd[cmd_idx].fd_infile != STDIN_FILENO)
 			dup2(cmd[cmd_idx].fd_infile, STDIN_FILENO);
 		else if (cmd_idx > 0)
 			dup2(cmd->pipes[cmd_idx - 1][0], STDIN_FILENO);
-
-		// Set up stdout
 		if (cmd[cmd_idx].fd_outfile != STDOUT_FILENO)
 			dup2(cmd[cmd_idx].fd_outfile, STDOUT_FILENO);
 		else if (cmd_idx < cmd->cmdnbr - 1)
 			dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
-		/**/
-		iter.i = 0;
-		while (iter.i < cmd->cmdnbr - 1)
-		{
-			close(cmd->pipes[iter.i][0]);
-			close(cmd->pipes[iter.i][1]);
-			iter.i++;
-		}
-		/**/
+		closefd(cmd, 0);
 		execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL, tenvp));
 		// TODO handle exit failure
 	}
@@ -80,6 +60,7 @@ static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp)
 		if (pipe(cmd->pipes[iter.i++]) == -1)
 			return ; // TODO handle exit failure
 	}
+	ft_cmdpathlist(cmd, tenvp);
 	iter.i = 0;
 	while (iter.i < cmd->cmdnbr)
 		fd_child(cmd, tenvp, iter.i++);
@@ -102,11 +83,8 @@ void	ft_pipex(t_cmd *cmd, t_list *tenvp)
 	cmd->cmdnbr = ft_nbrofcmds(cmd);
 	if (!ft_strncmp(cmd->args[0], "exit", 4) && cmd->cmdnbr == 1)
 		ft_exit(cmd->args, NULL);
-	ft_cmdpathlist(cmd, tenvp);
-	if (cmd->error == 1)
-		return ; // TODO exit failure free
 	fd_pipex_execute(cmd, tenvp);
-	g_status_code = 0; // TODO exit success free
+	g_status_code = cmd->error; // TODO exit success free
 }
 
 /*

--- a/src/pipex/ft_utils.c
+++ b/src/pipex/ft_utils.c
@@ -6,7 +6,7 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/01 13:34:25 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/01 13:35:27 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/04 14:45:15 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,22 @@
 #include "utils.h"
 #include "pipex.h"
 
-int  ft_nbrofcmds(t_cmd *cmd)
+void	closefd(t_cmd *cmd, int exitnbr)
+{
+	t_iteration	iter;
+
+	iter.i = 0;
+	while (iter.i < cmd->cmdnbr - 1)
+	{
+		close(cmd->pipes[iter.i][0]);
+		close(cmd->pipes[iter.i][1]);
+		iter.i++;
+	}
+	if (exitnbr)
+		exit(EXIT_FAILURE);
+}
+
+int		ft_nbrofcmds(t_cmd *cmd)
 {
 	int nbr;
 


### PR DESCRIPTION
This pull request introduces several updates to improve error handling, resource management, and code clarity in the `pipex` project. The most notable changes include the addition of a `closefd` utility function for closing file descriptors, modifications to the `ft_exit` function to simplify exit code handling, and refactoring in the `ft_pipex` function to streamline error management. Below is a breakdown of the most important changes:

### Error Handling and Resource Management

* **Addition of `closefd` function**: A new utility function `closefd` was added to close all file descriptors associated with `pipes` and optionally exit with a failure code. This centralizes resource cleanup and improves code reuse. (`src/pipex/ft_utils.c`, [src/pipex/ft_utils.cL9-R31](diffhunk://#diff-84111c506ecf619b3eb8156bd9562f14bdc732aec0d40b866fc7c1e42d806ef8L9-R31))
* **Integration of `closefd` in `fd_child`**: The `fd_child` function now uses `closefd` to handle resource cleanup and exit failures, replacing inline cleanup logic. (`src/pipex/ft_pipex.c`, [src/pipex/ft_pipex.cL19-R41](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cL19-R41))

### Refactoring and Simplification

* **Refactoring of `ft_pipex` function**: The `ft_pipex` function now delegates command path list initialization to `fd_pipex_execute`, removing duplicate logic and simplifying error handling. (`src/pipex/ft_pipex.c`, [src/pipex/ft_pipex.cL105-R87](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cL105-R87))
* **Removal of exit code range validation**: The `ft_exit` function no longer validates the exit code range (0–255), simplifying its implementation. (`src/base_commands/exit.c`, [src/base_commands/exit.cL72-L76](diffhunk://#diff-dc8eb70d071d7237e3e25ed3320f847a425a476a04e326422c8e8d3c2cdc8b05L72-L76))

### Structural and Typing Improvements

* **Change to `exit_code` type**: The `exit_code` variable in `ft_exit` was changed from `int` to `unsigned char`, aligning with the standard exit code representation. (`src/base_commands/exit.c`, [src/base_commands/exit.cL51-R51](diffhunk://#diff-dc8eb70d071d7237e3e25ed3320f847a425a476a04e326422c8e8d3c2cdc8b05L51-R51))

These changes collectively enhance the maintainability and reliability of the codebase while adhering to best practices for error handling and resource management.