### PR TITLE
Toaster

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -10,6 +10,7 @@ on:
       - toaster
     paths:
       - src/**
+      - .test/**
       - Makefile
       - include/**
       - .github/workflows/make.yml
@@ -18,6 +19,7 @@ on:
       - main
     paths:
       - src/**
+      - .test/**
       - Makefile
       - include/**
       - .github/workflows/make.yml

--- a/.test/test_exit.c
+++ b/.test/test_exit.c
@@ -65,7 +65,7 @@ Test(exit, argument_out_of_range)
 	int		code;
 
 	code = run_exit_and_get_code(args);
-	cr_assert_eq(code, 255, "exit with argument >255 should return (255");
+	cr_assert_eq(code, 44, "exit with argument 300 should return (44)");
 }
 
 Test(exit, negative_argument)

--- a/Makefile
+++ b/Makefile
@@ -243,4 +243,9 @@ check: $(HOME)/.local/bin/trunk
 	@$(HOME)/.local/bin/trunk check --all
 	@echo "Trunk check completed."
 
-.PHONY: all clean fclean re bundle
+format: $(HOME)/.local/bin/trunk
+	@echo "Running trunk format..."
+	@$(HOME)/.local/bin/trunk fmt --all
+	@echo "Trunk format completed."
+
+.PHONY: all clean fclean re bundle test run_test check format


### PR DESCRIPTION
This pull request introduces updates to the `.github/workflows/make.yml` file, modifies a test case in `.test/test_exit.c`, and adds a new `format` target to the `Makefile`. These changes improve test coverage, adjust test behavior, and enhance the build system's functionality.

### Workflow and build system updates:
* **Updated workflow paths**: Added `.test/**` to the `paths` section in `.github/workflows/make.yml` to ensure that changes in the `.test` directory trigger the workflow. [[1]](diffhunk://#diff-c619491a91da4d5ad74050f1334ec593c012af3e8d2be4b52539caf2e44ed090R13) [[2]](diffhunk://#diff-c619491a91da4d5ad74050f1334ec593c012af3e8d2be4b52539caf2e44ed090R22)
* **New `format` target in `Makefile`**: Introduced a `format` target to run `trunk fmt --all`, enabling automatic code formatting as part of the build process.

### Test case modification:
* **Adjusted test behavior in `.test/test_exit.c`**: Updated the expected behavior of the `exit` test to check for a return value of `44` when the argument is `300`, aligning the test with the new logic.