### PR TITLE
i sent a commit through minishell!!! and builtin 'works'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ SRCS     = \
   $(SRC_DIR)/pipex/cmd_path.c \
   $(SRC_DIR)/pipex/ft_errors.c \
   $(SRC_DIR)/pipex/ft_utils.c \
-  # TODO added $(SRC_DIR)/pipex/ft_errors.c \ TODO
+  $(SRC_DIR)/pipex/ft_builtin.c \
+  # TODO added $(SRC_DIR)/pipex/ft_builtin.c \ TODO
   
   
  # add the source files from SRCS to the test files excluding 'src/main.c'

--- a/include/shared.h
+++ b/include/shared.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:24:32 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/01 15:50:58 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/07 15:12:50 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@
 # include "libft.h"
 # include <stdbool.h>
 # include <stdint.h>
+
+# define NO_EXIT -1
 
 typedef struct s_reader t_reader;
 
@@ -92,7 +94,16 @@ void	ft_cmdpathlist(t_cmd *cmd, t_list *tenvp);
 void    closefd(t_cmd *cmd, int exitnbr);
 int		ft_nbrofcmds(t_cmd *cmd);
 
-// base_commands/exit.c
+// pipex/ft_builtin.c
+void	is_builtin(t_cmd *cmd, t_list **env, int cmd_idx);
+
+// base_commands/(...).c
+void	ft_cd(char **argv, t_list **envp);
+void	ft_echo(int argc, char **argv);
+int		ft_env(t_list **env);
 void	ft_exit(char **s, t_reader *reader);
+int		ft_export(char **argv, t_list **envp);
+int		ft_pwd(t_list **envp);
+int		ft_unset(char **args, t_list **envp);
 
 #endif

--- a/src/pipex/ft_builtin.c
+++ b/src/pipex/ft_builtin.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_builtin.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/07 09:38:39 by jfranc            #+#    #+#             */
+/*   Updated: 2025/07/07 15:21:30 by jfranc           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <shared.h>
+
+void is_builtin(t_cmd *cmd, t_list **env, int cmd_idx)
+{
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "cd", 2))
+		closefd(cmd, EXIT_SUCCESS);
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "echo", 4))
+	{
+		ft_echo(cmd[cmd_idx].argc, cmd[cmd_idx].args);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "env", 3))
+	{	
+		ft_env(env);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "exit", 4))
+	{
+		ft_exit(cmd[cmd_idx].args, NULL);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "export", 6))
+	{
+		ft_export(cmd[cmd_idx].args, env);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "pwd", 3))
+	{
+		ft_pwd(env);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+	if (!ft_strncmp(cmd[cmd_idx].args[0], "unset", 5))
+	{
+		ft_unset(cmd[cmd_idx].args, env);
+		closefd(cmd, EXIT_SUCCESS);
+	}
+}

--- a/src/pipex/ft_errors.c
+++ b/src/pipex/ft_errors.c
@@ -6,7 +6,7 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 18:51:56 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/01 13:36:41 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/07 10:19:07 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,7 @@ void ft_cmdpathlist(t_cmd *cmd, t_list *tenvp)
 	if (!cmd->cmdpathlist)
 	{
 		write(1, "malloc failure\n", 15);
-		g_status_code = 12;
-		cmd->error = 1;
+		cmd->error = 12;
 		return ;
 	}
 	iter.i = 0;
@@ -35,8 +34,7 @@ void ft_cmdpathlist(t_cmd *cmd, t_list *tenvp)
 		if (!cmd->cmdpathlist[iter.i])
 		{
 			printf("%s: command not found\n", cmd[iter.i].args[0]);
-			g_status_code = 127;
-			cmd->error = 1;
+			cmd->error = 127;
 		}
 		iter.i++;
 	}

--- a/src/pipex/ft_utils.c
+++ b/src/pipex/ft_utils.c
@@ -6,7 +6,7 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/01 13:34:25 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/04 14:45:15 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/07 14:23:55 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,8 @@ void	closefd(t_cmd *cmd, int exitnbr)
 		close(cmd->pipes[iter.i][1]);
 		iter.i++;
 	}
-	if (exitnbr)
-		exit(EXIT_FAILURE);
+	if (exitnbr > -1)
+		exit(exitnbr);
 }
 
 int		ft_nbrofcmds(t_cmd *cmd)


### PR DESCRIPTION
This pull request introduces support for built-in shell commands in the `pipex` project, along with improvements to error handling and code refactoring. The key changes include adding a new `ft_builtin.c` file to handle built-in commands, modifying error handling to use specific error codes, and refactoring the `pipex` logic for better clarity and maintainability.

### Built-in Commands Support:
* Added a new file `src/pipex/ft_builtin.c` to handle built-in commands like `cd`, `echo`, `env`, `exit`, `export`, `pwd`, and `unset`. The `is_builtin` function determines if a command is built-in and executes it. (`[src/pipex/ft_builtin.cR1-R49](diffhunk://#diff-e12e55ea87f026190b41ad78d3e74b8e82d5e464f568e1f284f1e79ad786a68eR1-R49)`)
* Updated `Makefile` to include `ft_builtin.c` in the source files. (`[MakefileL63-R64](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L63-R64)`)
* Declared new functions for built-in commands in `include/shared.h`. (`[include/shared.hL95-R107](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8L95-R107)`)

### Error Handling Improvements:
* Replaced generic error codes in `ft_cmdpathlist` with specific error values (e.g., `12` for memory allocation failure, `127` for command not found). (`[[1]](diffhunk://#diff-a72f76d0d75021ccadc12f31d1f8e9961aa17f7e8dad14921f15e094750bcbaeL27-R27)`, `[[2]](diffhunk://#diff-a72f76d0d75021ccadc12f31d1f8e9961aa17f7e8dad14921f15e094750bcbaeL38-R37)`)
* Updated the `closefd` function to allow more granular exit codes by checking if `exitnbr > -1`. (`[src/pipex/ft_utils.cL28-R29](diffhunk://#diff-84111c506ecf619b3eb8156bd9562f14bdc732aec0d40b866fc7c1e42d806ef8L28-R29)`)

### Pipex Refactoring:
* Introduced a `pipe_redirection` function in `src/pipex/ft_pipex.c` to simplify and centralize pipe redirection logic. (`[src/pipex/ft_pipex.cL9-R29](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cL9-R29)`)
* Integrated `is_builtin` into the child process logic to handle built-in commands before attempting to execute external commands. (`[src/pipex/ft_pipex.cR40-L41](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cR40-L41)`)
* Added support for directly executing `cd` and `exit` commands when only one command is provided. (`[src/pipex/ft_pipex.cR93-R97](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cR93-R97)`)

### Miscellaneous:
* Added a new macro `NO_EXIT` in `include/shared.h` for clarity when no exit is required. (`[include/shared.hR22-R23](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8R22-R23)`)