### PR TITLE
Toaster

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - toaster
+      - julien
     paths:
       - src/**
       - .test/**
@@ -44,7 +45,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get purge -y man-db
-          sudo apt-get install -y make clang wget tar gzip mold
+          # Install required packages for commands : bear, clang, make, mold, wget, tar, zip, xz
+          sudo apt-get install -y make clang wget tar gzip mold xz-utils zip
 
       - name: Build project
         run: make all

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ bundle:
 	@echo "Creating bundle for $(NAME)..."
 	@if command -v bear >/dev/null 2>&1; then \
 		echo "Using bear to generate compile_commands.json..."; \
-		bear -- ${MAKE} all CC=cc; \
+		bear -- ${MAKE} test all CC=cc; \
 	else \
 		${MAKE} all CC=cc; \
 	fi

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1301,7 +1301,7 @@
   },
   {
     "arguments": [
-      "/usr/lib64/ccache/cc",
+      "/usr/lib64/ccache/clang",
       "-Wall",
       "-Wextra",
       "-Werror",
@@ -1310,14 +1310,456 @@
       "-I./include",
       "-pipe",
       "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/main.o",
-      "src/main.c"
+      "target/test/test_lexer_basic.o",
+      ".test/test_lexer_basic.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/main.c",
-    "output": "/home/creid/Documents/42/minishell/target/main.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_basic.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_basic.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_lexer_redirections.o",
+      ".test/test_lexer_redirections.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_redirections.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_redirections.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_lexer_quotes.o",
+      ".test/test_lexer_quotes.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_quotes.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_quotes.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_lexer_complex.o",
+      ".test/test_lexer_complex.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_complex.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_complex.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_join_words.o",
+      ".test/test_join_words.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_join_words.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_join_words.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_lexer_utils.o",
+      ".test/test_lexer_utils.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_utils.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_utils.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_fromenvp.o",
+      ".test/test_b_fromenvp.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_fromenvp.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_fromenvp.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_getenv.o",
+      ".test/test_b_getenv.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_getenv.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_getenv.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_setenv.o",
+      ".test/test_b_setenv.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_setenv.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_setenv.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_unsetenv.o",
+      ".test/test_b_unsetenv.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_unsetenv.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_unsetenv.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_varexists.o",
+      ".test/test_b_varexists.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_varexists.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_varexists.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_parser_basic.o",
+      ".test/test_parser_basic.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_parser_basic.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_basic.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_parser_pipe.o",
+      ".test/test_parser_pipe.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_parser_pipe.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_pipe.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_utils.o",
+      ".test/test_utils.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_utils.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_utils.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_utils_string.o",
+      ".test/test_utils_string.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_utils_string.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_utils_string.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_utils_readline.o",
+      ".test/test_utils_readline.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_utils_readline.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_utils_readline.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_cd.o",
+      ".test/test_cd.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_cd.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_cd.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_env.o",
+      ".test/test_env.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_env.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_env.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_pwd.o",
+      ".test/test_pwd.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_pwd.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_pwd.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_unset.o",
+      ".test/test_unset.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_unset.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_unset.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_export.o",
+      ".test/test_export.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_export.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_export.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/clang",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_exit.o",
+      ".test/test_exit.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_exit.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_exit.o"
   },
   {
     "arguments": [
@@ -1832,6 +2274,26 @@
       "-I./target/libft/",
       "-c",
       "-o",
+      "target/utils/print_prompt.o",
+      "src/utils/print_prompt.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/print_prompt.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/print_prompt.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-c",
+      "-o",
       "target/parser/p_strerror.o",
       "src/parser/p_strerror.c"
     ],
@@ -2198,5 +2660,25 @@
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/pipex/ft_utils.c",
     "output": "/home/creid/Documents/42/minishell/target/pipex/ft_utils.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-g3",
+      "-std=c17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-c",
+      "-o",
+      "target/main.o",
+      "src/main.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/main.c",
+    "output": "/home/creid/Documents/42/minishell/target/main.o"
   }
 ]

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 14:38:32 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/01 13:45:39 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/07 11:42:45 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,8 @@
 # include "libft.h"
 # include "shared.h"
 
-typedef struct s_cmd t_cmd;
-typedef struct s_reader t_reader;
+typedef struct s_cmd	t_cmd;
+typedef struct s_reader	t_reader;
 
 /// - bit 0 : command is a builtin
 ///
@@ -46,7 +46,7 @@ typedef enum e_parsing_error
 	PARSING_MISSING_SPECIAL_TARGET = 2,
 	/// @brief Double special directive
 	PARSING_DOUBLE_SPECIAL_DIRECTIVE = 3,
-}					t_parsing_error;
+}						t_parsing_error;
 
 /// @brief Represents the current state of the parser.
 typedef enum e_parser_state
@@ -58,58 +58,58 @@ typedef enum e_parser_state
 	/// @brief The parser is currently processing a special token (e.g., pipe,
 	///         redirection).
 	PARSER_SPECIAL,
-}					t_parser_state;
+}						t_parser_state;
 
 /// @brief Represents the parser's state and data structures.
 typedef struct s_parser
 {
 	/// @brief A linked list of commands that have been parsed.
-	t_list			*command_list;
+	t_list				*command_list;
 	/// @brief The command currently being built.
-	t_cmd			*command;
+	t_cmd				*command;
 	/// @brief A linked list of arguments for the current command.
-	t_list			*argument_list;
+	t_list				*argument_list;
 
 	/// @brief The original list of tokens from the lexer.
-	t_list			*token_list;
+	t_list				*token_list;
 	/// @brief The token currently being processed.
-	t_token			*current_token;
+	t_token				*current_token;
 	/// @brief The type of the last token that was processed.
-	t_token_type	last_token_type;
+	t_token_type		last_token_type;
 
 	/// @brief The index of the current token in the token list.
-	size_t			current_index;
+	size_t				current_index;
 	/// @brief The total number of tokens to be parsed.
-	size_t			token_count;
+	size_t				token_count;
 
 	/// @brief The current state of the parser.
-	t_parser_state	state;
+	t_parser_state		state;
 	/// @brief The heredoc delimiter, if any.
-	char			*heredoc_delimiter;
+	char				*heredoc_delimiter;
 	/// @brief The current heredoc file descriptor, if any.
-	int				heredoc_fd;
+	int					heredoc_fd;
 
 	/// @brief The last error that occurred during parsing, if any.
-	t_parsing_error	error;
-}					t_parser;
+	t_parsing_error		error;
+}						t_parser;
 
 /// @brief Initialize the parser
 /// @param token_list The list of tokens to parse
 /// @return A pointer to the parser
-t_parser			*parser_init(t_list *token_list);
+t_parser				*parser_init(t_list *token_list);
 
 /// @brief Free the parser
 /// @param parser The parser to free
-void				parser_free(t_parser *parser);
+void					parser_free(t_parser *parser);
 
 /// @brief Free a command
 /// @param data The command to free
-void				free_command(void *data);
+void					free_command(void *data);
 
 /// @brief Parse the tokens
 /// @param parser The parser to use
 /// @return The parsing error
-t_parsing_error		parser_parse(t_parser *parser);
+t_parsing_error			parser_parse(t_parser *parser);
 
 /// @brief Gets the nth element of a linked list.
 /// @param lst The linked list.
@@ -117,45 +117,53 @@ t_parsing_error		parser_parse(t_parser *parser);
 /// @param size The total size of the list.
 /// @return A pointer to the content of the nth element,
 ///          or NULL if not found or if arguments are invalid.
-void				*ft_lstget(t_list *lst, size_t n, size_t size);
+void					*ft_lstget(t_list *lst, size_t n, size_t size);
 
-/// @brief Handles the initial state of the parser or when no specific command/special token is being processed.
-/// It determines if the current token is a command or a special token and transitions the parser state accordingly.
+/// @brief Handles the initial state of the parser or when no
+/// specific command/special token is being processed.
+/// It determines if the current token is a command or a special
+/// token and transitions the parser state accordingly.
 /// @param parser The parser instance.
-void				parser_handle_none(t_parser *parser);
+void					parser_handle_none(t_parser *parser);
 
-/// @brief Handles the state when the parser is processing a command and its arguments.
-/// It appends word tokens to the argument list. If a non-word token is encountered,
+/// @brief Handles the state when the parser is processing a
+/// command and its arguments.
+/// It appends word tokens to the argument list. If a non-word
+/// token is encountered,
 /// it transitions the parser state to handle special tokens.
 /// @param parser The parser instance.
-void				parser_handle_command(t_parser *parser);
+void					parser_handle_command(t_parser *parser);
 
 /// @brief Handles various special tokens (pipe,
 ///         redirections) based on the `last_token_type`.
-/// It calls the appropriate specific handler for the encountered special token.
-/// Sets parser error if an unexpected token sequence is found or if a required target for a special token is missing.
+/// It calls the appropriate specific handler for the encountered
+/// special token.
+/// Sets parser error if an unexpected token sequence is found or
+/// if a required
+/// target for a special token is missing.
 /// @param parser The parser instance.
-void				parser_handle_special(t_parser *parser);
+void					parser_handle_special(t_parser *parser);
 
-/// @brief Executes a single step in the parsing process based on the current parser state.
+/// @brief Executes a single step in the parsing process based on
+/// the current parser state.
 ///  It calls the appropriate handler function (parser_handle_none,
 ///  parser_handle_command, or parser_handle_special).
 /// @param parser The parser instance.
 /// @return A parsing error code, PARSING_NO_ERROR if the step was successful,
 ///          or an error code if an issue occurred.
-t_parsing_error		parser_step(t_parser *parser);
+t_parsing_error			parser_step(t_parser *parser);
 
 /// @brief Turns the AST into a list of commands
 /// @param parser The parser to use
 /// @return A list of commands
-t_cmd				*parser_to_list(t_parser *parser);
+t_cmd					*parser_to_list(t_parser *parser);
 
 /// @brief Allocate and initialize a command structure.
 /// @details Sets default values for arguments, redirections, and pipe flag.
 /// @return Pointer to the initialized t_cmd structure,
 ///          or NULL on allocation failure (errno set to ENOMEM).
-t_cmd				*cmd_init(void);
+t_cmd					*cmd_init(void);
 
-char				*p_strerror(t_parsing_error error);
+char					*p_strerror(t_parsing_error error);
 
 #endif

--- a/include/pipex.h
+++ b/include/pipex.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipex.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 17:49:37 by jfranc            #+#    #+#             */
-/*   Updated: 2025/04/08 16:09:34 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/07 11:41:29 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,15 @@
 # define PIPEX_H
 
 # include "shared.h"
-# include <libft.h>
-# include <unistd.h>
-# include <stdlib.h>
-# include <stdio.h>
-# include <sys/wait.h>
 # include <fcntl.h>
+# include <libft.h>
+# include <stdio.h>
+# include <stdlib.h>
+# include <sys/wait.h>
+# include <unistd.h>
 
-# define STDIN	0
-# define STDOUT	1
+# define STDIN 0
+# define STDOUT 1
 
 typedef struct s_path_data
 {
@@ -31,7 +31,7 @@ typedef struct s_path_data
 	char	*full_path;
 	char	*cmd;
 	int		i;
-}	t_path_data;
+}			t_path_data;
 
 typedef struct s_data
 {
@@ -43,13 +43,13 @@ typedef struct s_data
 	int		fd[2];
 	int		pid1;
 	int		pid2;
-}	t_data;
+}			t_data;
 
-//cmd_path.c
-void	ft_free_split(char **split);
-char	*ft_get_cmd_path(char *cmd, t_list *tenvp);
+// cmd_path.c
+void		ft_free_split(char **split);
+char		*ft_get_cmd_path(char *cmd, t_list *tenvp);
 
-//pipex_utils.c
-void	ft_error_exit(char *s);
+// pipex_utils.c
+void		ft_error_exit(char *s);
 
 #endif

--- a/include/reader.h
+++ b/include/reader.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 18:43:50 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/06/17 18:27:15 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/07 11:41:25 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,22 +20,21 @@
 # include <errno.h>
 # include <stdio.h>
 
-typedef struct s_parser t_parser;
-
+typedef struct s_parser	t_parser;
 
 typedef struct s_reader
 {
-	char		*cached;
-	t_lexer		*lexer;
-	t_list		*tokens;
-	t_parser	*parser;
-	t_list		*env;
-}				t_reader;
+	char				*cached;
+	t_lexer				*lexer;
+	t_list				*tokens;
+	t_parser			*parser;
+	t_list				*env;
+}						t_reader;
 
-t_reader		*reader_init(char *const *envp);
+t_reader				*reader_init(char *const *envp);
 
-void			reader_free(t_reader *reader);
+void					reader_free(t_reader *reader);
 
-void			handle_read(t_reader *reader, const char *input);
+void					handle_read(t_reader *reader, const char *input);
 
 #endif

--- a/include/shared.h
+++ b/include/shared.h
@@ -6,22 +6,22 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:24:32 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/01 15:50:58 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/07 11:41:14 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef SHARED_H
 # define SHARED_H
 
-# include "reader.h"
-# include "parser.h"
 # include "libft.h"
+# include "parser.h"
+# include "reader.h"
 # include <stdbool.h>
 # include <stdint.h>
 
-typedef struct s_reader t_reader;
+typedef struct s_reader	t_reader;
 
-extern int	g_status_code;
+extern int				g_status_code;
 
 /// @brief The structure to hold the environment variables
 /// @note This structure is used to create a linked list
@@ -29,70 +29,72 @@ extern int	g_status_code;
 typedef struct s_env
 {
 	/// @brief The key of the environment variable
-	char	*key;
+	char				*key;
 	/// @brief The value of the environment variable
-	char	*value;
-}			t_env;
+	char				*value;
+}						t_env;
 
 /// @brief Check if the environment variable exists in the list
 /// @param key The key of the environment variable
 /// @return true if the environment variable exists, false otherwise
-bool		b_varexists(const char *key, t_list *envp);
+bool					b_varexists(const char *key, t_list *envp);
 
 /// @brief Get the value of the environment variable
 /// @param key The key of the environment variable (if NULL, returns all)
 /// @return Array of strings: single value if key found, all env vars if NULL
 /// @note The caller is responsible for freeing the returned array and strings
-char		**b_getenv(const char *key, t_list *envp);
+char					**b_getenv(const char *key, t_list *envp);
 
 /// @brief Set the value of the environment variable
 /// @param key The key of the environment variable
 /// @param value The value to set
 /// @note The caller is responsible for freeing the value string
 ///       if it was dynamically allocated
-void		b_setenv(const char *key, const char *value, t_list **envp);
+void					b_setenv(const char *key, const char *value,
+							t_list **envp);
 
 /// @brief Unset the environment variable
 /// @param key The key of the environment variable
 /// @param del The function to call to delete the value
 /// @note The caller is responsible for setting the correct delete function
-void		b_unsetenv(const char *key, void (*del)(void *), t_list **envp);
+void					b_unsetenv(const char *key, void (*del)(void *),
+							t_list **envp);
 
-t_list		*b_fromenvp(char *const *envp);
+t_list					*b_fromenvp(char *const *envp);
 
 typedef struct s_cmd
 {
-	bool	is_pipe;
-	bool	error;
-	int		pid;
-	int		argc;
-	int		cmdnbr;
-	int		fd_infile;
-	int		fd_outfile;
-	int		**pipes;
-	int     fd[2];
-	char	**args;
-	char	**cmdpathlist;
-	char	*redirect_in;
-	char	*redirect_out;
-	char	*redirect_append;
-	char	*redirect_heredoc;
-}			t_cmd;                                    
-                                                      
-//pipex/ft_pipex.c                                    
-void	ft_pipex(t_cmd *cmd, t_list *tenvp);
+	bool				is_pipe;
+	bool				error;
+	int					pid;
+	int					argc;
+	int					cmdnbr;
+	int					fd_infile;
+	int					fd_outfile;
+	int					**pipes;
+	int					fd[2];
+	char				**args;
+	char				**cmdpathlist;
+	char				*redirect_in;
+	char				*redirect_out;
+	char				*redirect_append;
+	char				*redirect_heredoc;
+}						t_cmd;
 
-//pipex/cmd_path.c                                    
-void	ft_free_split(char **split);
+// pipex/ft_pipex.c
+void					ft_pipex(t_cmd *cmd, t_list *tenvp);
 
-//pipex/ft_error.c                                    
-void	ft_cmdpathlist(t_cmd *cmd, t_list *tenvp);
+// pipex/cmd_path.c
+void					ft_free_split(char **split);
+
+// pipex/ft_error.c
+void					ft_cmdpathlist(t_cmd *cmd, t_list *tenvp);
 
 // pipex/ft_utils.c
-void    closefd(t_cmd *cmd, int exitnbr);
-int		ft_nbrofcmds(t_cmd *cmd);
+void					closefd(t_cmd *cmd, int exitnbr);
+int						ft_nbrofcmds(t_cmd *cmd);
 
 // base_commands/exit.c
-void	ft_exit(char **s, t_reader *reader);
+void					ft_exit(char **s, t_reader *reader);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/12 15:31:30 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/04 13:48:51 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/07 11:40:44 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,9 +32,12 @@
  */
 typedef struct s_iteration
 {
-	int i; /**< First iteration counter */
-	int j; /**< Second iteration counter */
-	int k; /**< Third iteration counter */
+	// First iteration counter
+	int				i;
+	// Second iteration counter
+	int				j;
+	// Third iteration counter
+	int				k;
 }					t_iteration;
 
 /**
@@ -47,8 +50,10 @@ typedef struct s_iteration
  */
 typedef struct s_linereader
 {
-	char *line; /**< Current line buffer */
-	int fd;     /**< File descriptor to read from */
+	// Current line buffer
+	char			*line;
+	// File descriptor to read from
+	int				fd;
 }					t_linereader;
 
 /**
@@ -182,26 +187,25 @@ char				*ft_readstr(int fd, int len);
  */
 typedef struct s_file
 {
-	char *path; /**< Path to the file */
-	int fd;     /**< File descriptor for the opened file */
+	// Path to the file
+	char			*path;
+	// File descriptor for the opened file
+	int				fd;
 }					t_file;
 
-/**
- * @brief Creates a temporary file with optional automatic unlinking
- * @param rand_fd File descriptor for random number generation
- * @param auto_unlink If true,
-	the file will be automatically unlinked after creation
- * @return Pointer to a t_file structure representing the temporary file,
-	or NULL on failure
- *
-
-	* This function creates a temporary file using the provided random file descriptor
- * to generate a unique filename. If auto_unlink is true,
-	the file will be unlinked
- * immediately after creation,
-	making it accessible only through the file descriptor.
- * The caller is responsible for freeing the returned t_file structure.
- */
+/// @brief Creates a temporary file with optional automatic unlinking
+/// @param rand_fd File descriptor for random number generation
+/// @param auto_unlink If true,
+/// the file will be automatically unlinked after creation
+/// @return Pointer to a t_file structure representing the temporary file,
+/// or NULL on failure
+///
+/// This function creates a temporary file using the provided
+/// random file descriptor
+/// to generate a unique filename. If auto_unlink is true,
+/// the file will be unlinked immediately after creation,
+/// making it accessible only through the file descriptor.
+/// The caller is responsible for freeing the returned t_file structure.
 t_file				*ft_opentmp(int rand_fd, bool auto_unlink);
 
 void				print_prompt(t_list *env);

--- a/src/parser/parser_parse.c
+++ b/src/parser/parser_parse.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/09 10:25:58 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/01 14:29:23 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/07 14:31:17 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -268,19 +268,19 @@ static void	parser_special_redirect_append(t_parser *parser)
 		return ;
 	}
 	fd = open(token->value, O_WRONLY | O_CREAT | O_APPEND, 0644);
+	if (parser->command == NULL)
+		parser->command = cmd_init();
 	if (fd < 0)
 	{
 		errno = EINVAL;
 		parser->error = PARSING_MISSING_SPECIAL_TARGET;
 		return ;
 	}
-	if (parser->command == NULL)
-		parser->command = cmd_init();
+	parser->command->fd_outfile = fd;
 	if (errno == ENOMEM)
 		return ;
-	parser->command->fd_outfile = fd;
 	parser->command->redirect_append = ft_strdup(token->value);
-	if (parser->command->redirect_in == NULL)
+	if (parser->command->redirect_append == NULL)
 	{
 		close(fd);
 		errno = ENOMEM;


### PR DESCRIPTION
This pull request introduces several updates across multiple files, focusing on workflow improvements, code formatting, and bug fixes. The most significant changes include adding a new branch to the CI workflow, updating package installation commands, modifying the parser's behavior during redirection handling, and improving code readability through consistent formatting.

### Workflow and Build Improvements:
* [`.github/workflows/make.yml`](diffhunk://#diff-c619491a91da4d5ad74050f1334ec593c012af3e8d2be4b52539caf2e44ed090R11): Added the `julien` branch to the CI workflow and updated the package installation commands to include `xz-utils` and `zip` for additional functionality. [[1]](diffhunk://#diff-c619491a91da4d5ad74050f1334ec593c012af3e8d2be4b52539caf2e44ed090R11) [[2]](diffhunk://#diff-c619491a91da4d5ad74050f1334ec593c012af3e8d2be4b52539caf2e44ed090L47-R49)

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L189-R189): Modified the `bundle` target to include the `test` target when generating `compile_commands.json` using `bear`, ensuring test commands are captured.

### Parser Bug Fix:
* [`src/parser/parser_parse.c`](diffhunk://#diff-2ecc21e99c5e7e0ca3f0f52ad93573ac4d6314eb7fd405f5617ead37b216bb57R271-R283): Fixed an issue where the parser did not initialize the command structure (`cmd_init`) before assigning the `fd_outfile` during redirection handling, preventing potential null pointer dereferences.

### Code Formatting and Readability Enhancements:
* Header files (`include/parser.h`, `include/shared.h`, `include/utils.h`, etc.): Reformatted comments and data structures for improved readability and consistency, including aligning member variables and splitting long comment lines. [[1]](diffhunk://#diff-3b2df7c1bd222e92cf09a90765c2c75bf7353069fd6ff0ea90b4d5a280d0823bL122-R148) [[2]](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8L53-R61) [[3]](diffhunk://#diff-95e9251d9e82720a3917beffdcad74f93a0f67b12b4388c9de6205ce71874024L185-R208)

### Minor Updates:
* Updated file metadata in headers across multiple files to reflect the latest modification date and author changes. [[1]](diffhunk://#diff-3b2df7c1bd222e92cf09a90765c2c75bf7353069fd6ff0ea90b4d5a280d0823bL9-R9) [[2]](diffhunk://#diff-4e37dd428f2285678ee966c2d123945b826bc3c9a3b005a6b1239f4d7d7b1732L6-R22) [[3]](diffhunk://#diff-5b5e7ca70b687d76d1c230aee01c9d4c8d22c9e3b7cd778eb99e2cb42fde5d40L9-R9) [[4]](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8L9-R18) [[5]](diffhunk://#diff-95e9251d9e82720a3917beffdcad74f93a0f67b12b4388c9de6205ce71874024L9-R9) [[6]](diffhunk://#diff-2ecc21e99c5e7e0ca3f0f52ad93573ac4d6314eb7fd405f5617ead37b216bb57L9-R9)