### PR TITLE
fix(pipex): handle export and unset builtins in parent process

### DIFF
--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -3,28 +3,28 @@
 /*                                                        :::      ::::::::   */
 /*   ft_pipex.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:03:33 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/07 17:42:21 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/10 11:37:34 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "pipex.h"
 #include "shared.h"
 #include "utils.h"
-#include "pipex.h"
 
 static void	pipe_redirection(t_cmd *cmd, int cmd_idx)
 {
-		if (cmd[cmd_idx].fd_infile != STDIN_FILENO)
-			dup2(cmd[cmd_idx].fd_infile, STDIN_FILENO);
-		else if (cmd_idx > 0)
-			dup2(cmd->pipes[cmd_idx - 1][0], STDIN_FILENO);
-		if (cmd[cmd_idx].fd_outfile != STDOUT_FILENO)
-			dup2(cmd[cmd_idx].fd_outfile, STDOUT_FILENO);
-		else if (cmd_idx < cmd->cmdnbr - 1)
-			dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
-		closefd(cmd, NO_EXIT);
+	if (cmd[cmd_idx].fd_infile != STDIN_FILENO)
+		dup2(cmd[cmd_idx].fd_infile, STDIN_FILENO);
+	else if (cmd_idx > 0)
+		dup2(cmd->pipes[cmd_idx - 1][0], STDIN_FILENO);
+	if (cmd[cmd_idx].fd_outfile != STDOUT_FILENO)
+		dup2(cmd[cmd_idx].fd_outfile, STDOUT_FILENO);
+	else if (cmd_idx < cmd->cmdnbr - 1)
+		dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
+	closefd(cmd, NO_EXIT);
 }
 
 static void	fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx)
@@ -46,16 +46,17 @@ static void	fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx)
 		if (!cmd->cmdpathlist[cmd_idx])
 			closefd(cmd, EXIT_FAILURE); // TODO exit failure free
 		*/
-		execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL, tenvp));
+		execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL,
+				tenvp));
 		// TODO handle exit failure
 	}
 }
 
-//iter.i, in fd_child indicates the command nbr
-//waitpdid->(cmd[iter.i].pid, ...) and fd_child(cmd, tenvp, iter.i++) teamwork
+// iter.i, in fd_child indicates the command nbr
+// waitpdid->(cmd[iter.i].pid, ...) and fd_child(cmd, tenvp, iter.i++) teamwork
 static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp)
 {
-	t_iteration iter;
+	t_iteration	iter;
 
 	cmd->pipes = malloc(sizeof(int *) * (cmd->cmdnbr - 1));
 	if (!cmd->pipes)
@@ -72,7 +73,7 @@ static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp)
 	while (iter.i < cmd->cmdnbr)
 		fd_child(cmd, tenvp, iter.i++);
 	iter.i = 0;
-	while (iter.i < cmd->cmdnbr - 1) 
+	while (iter.i < cmd->cmdnbr - 1)
 	{
 		close(cmd->pipes[iter.i][0]);
 		close(cmd->pipes[iter.i++][1]);
@@ -83,7 +84,7 @@ static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp)
 			return ; // TODO handle exit failure
 }
 
-//WARNING cmdpathlist does a malloc and contains mallocs
+// WARNING cmdpathlist does a malloc and contains mallocs
 void	ft_pipex(t_cmd *cmd, t_list *tenvp)
 {
 	cmd->error = 0;
@@ -91,10 +92,20 @@ void	ft_pipex(t_cmd *cmd, t_list *tenvp)
 	if (!ft_strncmp(cmd->args[0], "exit", 5) && cmd->cmdnbr == 1)
 		ft_exit(cmd->args, NULL);
 	if (!ft_strncmp(cmd->args[0], "cd", 3) && cmd->cmdnbr == 1)
-    {
-        ft_cd(cmd->args, &tenvp);
+	{
+		ft_cd(cmd->args, &tenvp);
 		return ;
-    }
+	}
+	if (!ft_strncmp(cmd->args[0], "export", 7) && cmd->cmdnbr == 1)
+	{
+		ft_export(cmd->args, &tenvp);
+		return ;
+	}
+	if (!ft_strncmp(cmd->args[0], "unset", 6) && cmd->cmdnbr == 1)
+	{
+		ft_unset(cmd->args, &tenvp);
+		return ;
+	}
 	fd_pipex_execute(cmd, tenvp);
 	g_status_code = cmd->error; // TODO exit success free
 }
@@ -103,8 +114,8 @@ void	ft_pipex(t_cmd *cmd, t_list *tenvp)
 void	ft_pipex(t_cmd *cmd, t_list *tenvp)
 {
 	t_iteration	iter;
-	//int			exit_code;
 
+	//int			exit_code;
 	iter.i = 0;
 	while (cmd->args[iter.i])
 	{


### PR DESCRIPTION
• Add direct execution for `export` and `unset` when `cmdnbr == 1`
• Prevent environment variable changes from being lost in child processes
• Align with existing `cd` builtin handling pattern
• **Components affected**: `ft_pipex()` execution flow
• Fix indentation and comment formatting per 42 style guidelines

This resolves the issue where `export VAR=value` commands would not
persist environment changes to the parent shell process.
