### PR TITLE
feat(signal): implement custom SIGINT and EOF handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ SRCS     = \
   $(SRC_DIR)/pipex/ft_builtin.c \
 	\
 	$(SRC_DIR)/varextract/extract_var_list.c \
+	\
+	$(SRC_DIR)/sigint/register_reader.c \
+	$(SRC_DIR)/sigint/sigint_handler.c \
   # TODO added $(SRC_DIR)/pipex/ft_builtin.c \ TODO
   
   

--- a/include/reader.h
+++ b/include/reader.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 18:43:50 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/09 14:45:09 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/11 14:12:28 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,14 @@
 
 typedef struct s_parser	t_parser;
 
+typedef enum e_reader_state
+{
+	READING,
+	LEXING,
+	PARSING,
+	EXECUTING,
+}						t_reader_state;
+
 typedef struct s_reader
 {
 	char				*cached;
@@ -30,6 +38,8 @@ typedef struct s_reader
 	t_parser			*parser;
 	t_list				*env;
 	t_list				*vars;
+	int					*pids;
+	t_reader_state		state;
 }						t_reader;
 
 t_reader				*reader_init(char *const *envp);

--- a/include/sigint.h
+++ b/include/sigint.h
@@ -1,0 +1,23 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   sigint.h                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/10 15:33:51 by lfiorell@st       #+#    #+#             */
+/*   Updated: 2025/07/11 15:17:27 by lfiorell@st      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef SIGINT_H
+# define SIGINT_H
+
+# include "reader.h"
+# include <signal.h>
+
+void	sigint_handler(int sig);
+
+void	register_reader(void);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:49:10 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/08 18:21:22 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/11 15:32:05 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "parser.h"
 #include "reader.h"
 #include "shared.h"
+#include "sigint.h"
 #include "utils.h"
 #include <errno.h>
 #include <readline/history.h>
@@ -141,6 +142,9 @@ int	main(int argc, char **argv, char **envp)
 	ft_bzero(&reader, sizeof(t_linereader));
 	cached_input = NULL;
 	reader_ptr = reader_init(envp);
+	// Disable readline's default signal handling to use custom handlers
+	rl_catch_signals = 0;
+	register_reader();
 	(void)argc;
 	(void)argv;
 	while (1)
@@ -152,7 +156,9 @@ int	main(int argc, char **argv, char **envp)
 		{
 			if (errno == EINTR)
 				continue ; // Handle interrupted read
-			break ;        // Exit on EOF or error
+			// Print exit on EOF (Ctrl+D)
+			write(1, "exit\n", 5);
+			break ; // Exit on EOF or error
 		}
 		handle_read(reader_ptr, cached_input);
 		free(cached_input);

--- a/src/sigint/register_reader.c
+++ b/src/sigint/register_reader.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   register_reader.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/10 16:09:52 by lfiorell@st       #+#    #+#             */
+/*   Updated: 2025/07/11 15:37:04 by lfiorell@st      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#define _POSIX_C_SOURCE 200809L
+#include "shared.h"
+#include "sigint.h"
+#include "utils.h"
+#include <signal.h>
+#include <stdio.h>
+
+void	register_reader(void)
+{
+	struct sigaction	sa;
+
+	sa.sa_handler = sigint_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, NULL);
+}

--- a/src/sigint/sigint_handler.c
+++ b/src/sigint/sigint_handler.c
@@ -1,0 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   sigint_handler.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/10 16:11:33 by lfiorell@st       #+#    #+#             */
+/*   Updated: 2025/07/11 15:37:00 by lfiorell@st      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#define _POSIX_C_SOURCE 200809L
+#include "shared.h"
+#include "sigint.h"
+#include <readline/readline.h>
+#include <signal.h>
+#include <unistd.h>
+
+void	sigint_handler(int sig)
+{
+	if (sig == SIGINT)
+	{
+		g_status_code = 130;
+		write(1, "\n", 1);
+		rl_on_new_line();
+		rl_replace_line("", 0);
+		rl_redisplay();
+	}
+}


### PR DESCRIPTION
This pull request introduces custom signal handling for `SIGINT` (Ctrl+C) and integrates it into the application's main loop. It also adds a new `t_reader_state` enum and modifies the `t_reader` struct to support the new functionality. Below are the key changes grouped by theme:

### Signal Handling Enhancements
* Added a new `sigint_handler` function to handle `SIGINT` signals, ensuring the application gracefully interrupts and updates the status code (`src/sigint/sigint_handler.c`).
* Introduced a `register_reader` function to register the custom `SIGINT` handler using `sigaction` (`src/sigint/register_reader.c`).
* Updated `main.c` to disable readline's default signal handling and register the custom signal handler (`src/main.c`).

### Reader State Management
* Added a new `t_reader_state` enum to define states like `READING`, `LEXING`, `PARSING`, and `EXECUTING` (`include/reader.h`).
* Extended the `t_reader` struct to include a `state` field of type `t_reader_state` and a `pids` field for process management (`include/reader.h`).

### Codebase Integration
* Included the new `sigint.h` header in `main.c` to access the signal handling functions (`src/main.c`).
* Added the new signal handling source files (`register_reader.c` and `sigint_handler.c`) to the `Makefile` for compilation (`Makefile`).

These changes improve the application's robustness by enabling custom handling of `SIGINT` signals and enhancing the reader's state management capabilities.• Introduce a dedicated `sigint` module to manage `SIGINT` (Ctrl+C) signals, allowing for context-aware responses. • Disable `readline`'s default `rl_catch_signals` to enable custom signal interception. • Enhance the `t_reader` struct with a `t_reader_state` enum (`READING`, `EXECUTING`, etc.) to track the shell's current operational state. • Add logic to print "exit" to the terminal on `EOF` (Ctrl+D) for a more standard and user-friendly shell exit.