### PR TITLE
fix(memory): address leaks and improve cleanup

### DIFF
--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,58 @@
+# Readline library suppressions
+{
+   readline_keymap_init
+   Memcheck:Leak
+   ...
+   fun:rl_make_bare_keymap
+   ...
+}
+
+{
+   readline_initialization
+   Memcheck:Leak
+   ...
+   fun:rl_initialize
+   ...
+}
+
+{
+   readline_bind_keys
+   Memcheck:Leak
+   ...
+   fun:rl_generic_bind
+   ...
+}
+
+{
+   readline_parse_and_bind
+   Memcheck:Leak
+   ...
+   fun:rl_parse_and_bind
+   ...
+}
+
+{
+   readline_read_init_file
+   Memcheck:Leak
+   ...
+   fun:_rl_read_init_file
+   ...
+}
+
+{
+   readline_xmalloc
+   Memcheck:Leak
+   ...
+   fun:xmalloc
+   ...
+}
+
+{
+   readline_internal_malloc
+   Memcheck:Leak
+   ...
+   fun:malloc
+   ...
+   fun:readline
+   ...
+}

--- a/src/lexer/join_words.c
+++ b/src/lexer/join_words.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/20 11:14:25 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/03 11:37:37 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 13:31:02 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,7 @@ static void	try_join(t_list *token)
 		return ;
 	joined_value = get_joined_value(current, next);
 	new_token = create_token(joined_value, TOKEN_WORD);
+	free(joined_value);
 	if (!new_token)
 		return ;
 	del = token->next;

--- a/src/reader/reader_free.c
+++ b/src/reader/reader_free.c
@@ -6,11 +6,12 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 19:34:24 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/06/16 19:35:15 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 13:39:32 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "reader.h"
+#include <readline/readline.h>
 
 void	reader_free(t_reader *reader)
 {
@@ -49,5 +50,6 @@ void	reader_free(t_reader *reader)
 	if (reader->varnames)
 		free(reader->varnames);
 	free(reader);
+	rl_clear_history();
 	errno = 0;
 }


### PR DESCRIPTION
• Added `free(joined_value)` in `src/lexer/join_words.c` to prevent memory leaks during token joining.
• Integrated `rl_clear_history()` in `src/reader/reader_free.c` for proper readline history cleanup.
• Introduced `readline.supp` file to suppress Valgrind warnings for known Readline library leaks.

Affected components:
• Lexer (`join_words.c`)
• Reader (`reader_free.c`)
• Valgrind suppression (`readline.supp`)
