### PR TITLE
fix(pipex, reader): improve memory management and error handling

### DIFF
--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:03:33 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/17 13:13:05 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 14:02:41 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,7 @@ void	ft_pipex(t_cmd *cmd, t_list *tenvp, t_reader *exit)
 	cmd->error = 0;
 	cmd->cmdnbr = ft_nbrofcmds(cmd);
 	if (!ft_strncmp(cmd->args[0], "exit", 5) && cmd->cmdnbr == 1)
-		ft_exit(cmd->args, NULL);
+		ft_exit(cmd->args, exit);
 	if (!ft_strncmp(cmd->args[0], "cd", 3) && cmd->cmdnbr == 1)
 	{
 		ft_cd(cmd->args, &tenvp);

--- a/src/reader/reader_free.c
+++ b/src/reader/reader_free.c
@@ -6,17 +6,22 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 19:34:24 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/17 13:39:32 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 14:11:11 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "reader.h"
 #include <readline/readline.h>
 
+void	free_env(void *env)
+{
+	free(((t_env *)env)->key);
+	free(((t_env *)env)->value);
+	free(env);
+}
+
 void	reader_free(t_reader *reader)
 {
-	size_t	i;
-
 	if (reader == NULL)
 		return ;
 	if (reader->cached)
@@ -27,10 +32,8 @@ void	reader_free(t_reader *reader)
 		free_lexer(reader->lexer);
 	if (reader->parser)
 		parser_free(reader->parser);
-	if (reader->tokens)
-		ft_lstclear(&reader->tokens, (void (*)(void *))free_token);
 	if (reader->env)
-		ft_lstclear(&reader->env, free);
+		ft_lstclear(&reader->env, free_env);
 	if (reader->linereader)
 	{
 		if (reader->linereader->line)
@@ -38,18 +41,9 @@ void	reader_free(t_reader *reader)
 		free(reader->linereader);
 	}
 	if (reader->commands)
-	{
-		i = 0;
-		while (reader->commands[i].args)
-		{
-			free_command_contents(&reader->commands[i]);
-			i++;
-		}
 		free(reader->commands);
-	}
 	if (reader->varnames)
 		free(reader->varnames);
 	free(reader);
 	rl_clear_history();
-	errno = 0;
 }


### PR DESCRIPTION
• Updated `ft_pipex.c` to pass `exit` to `ft_exit` for better error context.
• Refactored `reader_free.c`:
  - Added `free_env` function to properly free environment variables.
  - Replaced direct `free` calls with `free_env` in `ft_lstclear`.
  - Removed redundant loop for freeing `commands` array.
• Ensures consistent cleanup and reduces potential memory leaks.
