### PR TITLE
fix(memory): add suppression for readline_set_prompt leaks

### DIFF
--- a/readline.supp
+++ b/readline.supp
@@ -56,3 +56,11 @@
    fun:readline
    ...
 }
+
+{
+   readline_set_prompt
+   Memcheck:Leak
+   ...
+   fun:rl_set_prompt
+   ...
+}


### PR DESCRIPTION
• Extend `readline.supp` to suppress memory leaks related to `rl_set_prompt`
• Improves Valgrind compatibility for `readline` library usage
• Affects memory management during prompt updates
