### PR TITLE
leak progress

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:24:32 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/17 10:41:36 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 14:51:07 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,7 +115,7 @@ void					ft_cleanup_cmd(t_cmd *cmd);
 int						ft_nbrofcmds(t_cmd *cmd);
 
 // pipex/ft_builtin.c
-void					is_builtin(t_cmd *cmd, t_list **env, int cmd_idx);
+void					is_builtin(t_cmd *cmd, t_list **env, int cmd_idx, t_reader *exit);
 
 // base_commands/(...).c
 void					ft_cd(char **argv, t_list **envp);

--- a/src/pipex/cmd_path.c
+++ b/src/pipex/cmd_path.c
@@ -6,7 +6,7 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/07 13:21:12 by jfranc            #+#    #+#             */
-/*   Updated: 2025/06/30 13:38:15 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/17 14:44:55 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,9 +39,13 @@ static char	*ft_check_direct_path(char *cmd)
 char	*ft_get_cmd_path(char *cmd, t_list *tenvp)
 {
 	t_path_data	pd;
+	char **freeleak;
 
 	pd.full_path = NULL;
-	pd.paths = ft_split(*b_getenv("PATH", tenvp), ':');
+	freeleak = b_getenv("PATH", tenvp);
+	pd.paths = ft_split(*freeleak, ':');
+	free(*freeleak);
+	free(freeleak);
 	pd.full_path = ft_check_direct_path(cmd);
 	if (pd.full_path)
 		return (pd.full_path);

--- a/src/pipex/ft_builtin.c
+++ b/src/pipex/ft_builtin.c
@@ -6,50 +6,50 @@
 /*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/07 09:38:39 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/17 14:33:04 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/17 14:52:10 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <shared.h>
 
-static void	is_builtin2(t_cmd *cmd, t_list **env, int cmd_idx)
+static void	is_builtin2(t_cmd *cmd, t_list **env, int cmd_idx, t_reader *exit)
 {
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "pwd", 4))
 	{
 		ft_pwd(env);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "unset", 6))
 	{
 		ft_unset(cmd[cmd_idx].args, env);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "exit", 5))
 	{
 		ft_cleanup_cmd(cmd);
-		ft_exit(cmd[cmd_idx].args, NULL);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		ft_exit(cmd[cmd_idx].args, exit);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
 }
 
-void	is_builtin(t_cmd *cmd, t_list **env, int cmd_idx)
+void	is_builtin(t_cmd *cmd, t_list **env, int cmd_idx, t_reader *exit)
 {
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "cd", 3))
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "echo", 5))
 	{
 		ft_echo(cmd[cmd_idx].argc, cmd[cmd_idx].args);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "env", 4))
 	{
 		ft_env(env);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "export", 7))
 	{
 		ft_export(cmd[cmd_idx].args, env);
-		closefd(cmd, EXIT_SUCCESS, NULL);
+		closefd(cmd, EXIT_SUCCESS, exit);
 	}
-	is_builtin2(cmd, env, cmd_idx);
+	is_builtin2(cmd, env, cmd_idx, exit);
 }

--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:03:33 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/17 14:02:41 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 14:51:24 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,11 +42,11 @@ static void	fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx, t_reader *exit)
 	if (cmd[cmd_idx].pid == 0)
 	{
 		pipe_redirection(cmd, cmd_idx);
-		is_builtin(cmd, &tenvp, cmd_idx);
+		is_builtin(cmd, &tenvp, cmd_idx, exit);
 		if (cmd->error == 1)
-			closefd(cmd, EXIT_FAILURE, NULL);
+			closefd(cmd, EXIT_FAILURE, exit);
 		if (!cmd->cmdpathlist[cmd_idx])
-			closefd(cmd, EXIT_FAILURE, NULL);
+			closefd(cmd, EXIT_FAILURE, exit);
 		execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL,
 				tenvp));
 		closefd(cmd, EXIT_FAILURE, exit);


### PR DESCRIPTION
This pull request introduces changes to improve memory management and enhance the handling of the `exit` parameter in various functions across the codebase. The most significant updates include modifications to the `is_builtin` function and its helper functions, adjustments to memory allocation and cleanup in `cmd_path.c`, and updates to the `fd_child` function in `ft_pipex.c`.

### Memory Management Improvements:

* **`src/pipex/cmd_path.c`:** Added proper cleanup for dynamically allocated memory when retrieving and splitting the `PATH` environment variable. This ensures that memory leaks are avoided by freeing both the original environment variable and the split array.

### Enhanced `exit` Parameter Handling:

* **`src/pipex/ft_builtin.c`:** Updated the `is_builtin` and `is_builtin2` functions to accept a `t_reader *exit` parameter. This parameter is now passed to `closefd` and `ft_exit` calls, improving the handling of exit-related operations and ensuring consistency.
* **`include/shared.h`:** Updated the function signature of `is_builtin` to include the `t_reader *exit` parameter, reflecting the changes made in its implementation.
* **`src/pipex/ft_pipex.c`:** Modified the `fd_child` function to pass the `exit` parameter to `is_builtin` and `closefd`. This ensures unified handling of exit-related operations within child processes.