### PR TITLE
fix(pipex): correct cleanup logic in `closefd`

### DIFF
--- a/src/pipex/ft_builtin.c
+++ b/src/pipex/ft_builtin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_builtin.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/07 09:38:39 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/17 14:52:10 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/17 14:56:21 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,6 @@ static void	is_builtin2(t_cmd *cmd, t_list **env, int cmd_idx, t_reader *exit)
 	}
 	if (!ft_strncmp(cmd[cmd_idx].args[0], "exit", 5))
 	{
-		ft_cleanup_cmd(cmd);
 		ft_exit(cmd[cmd_idx].args, exit);
 		closefd(cmd, EXIT_SUCCESS, exit);
 	}

--- a/src/pipex/ft_utils.c
+++ b/src/pipex/ft_utils.c
@@ -3,17 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   ft_utils.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jfranc <jfranc@student.42nice.fr>          +#+  +:+       +#+        */
+/*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/01 13:34:25 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/16 17:33:48 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/17 15:03:02 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "reader.h"
 #include "shared.h"
 #include "utils.h"
 #include <unistd.h>
-#include "reader.h"
 
 void	ft_cleanup_cmd(t_cmd *cmd)
 {
@@ -46,13 +46,15 @@ void	closefd(t_cmd *cmd, int exitnbr, t_reader *reader)
 		close(cmd->pipes[iter.i][1]);
 		iter.i++;
 	}
-	if (reader)
-		reader_free(reader);
 	if (exitnbr > -1)
 	{
 		ft_cleanup_cmd(cmd);
+		if (reader)
+			reader_free(reader);
 		exit(exitnbr);
 	}
+	if (reader)
+		reader_free(reader);
 }
 
 int	ft_nbrofcmds(t_cmd *cmd)


### PR DESCRIPTION
• Adjusted `reader_free` calls in `closefd` to ensure proper cleanup
• Removed redundant `ft_cleanup_cmd` invocation in `ft_builtin.c`
• Updated headers in `ft_utils.c` for consistency
