### PR TITLE
fix(memory): ensure proper cleanup in env and lexer

### DIFF
--- a/src/base_commands/env.c
+++ b/src/base_commands/env.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/18 11:30:46 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/10 14:34:41 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 15:12:01 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,9 @@ void	ft_env(t_list **env)
 	{
 		write(1, envp[iteri], ft_strlen(envp[iteri]));
 		write(1, "\n", 1);
+		free(envp[iteri]);
 		iteri++;
 	}
+	free(envp);
 	g_status_code = 0;
 }

--- a/src/lexer/lexer_special.c
+++ b/src/lexer/lexer_special.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/16 16:44:26 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/16 16:45:19 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/17 15:10:49 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,8 +43,16 @@ static t_token	*make_special_token(const char *text, int pos, bool special,
 		t_token_type type)
 {
 	t_token	*token;
+	char	*substr;
 
-	token = create_token(ft_substr(text, pos, 1 + special), type);
+	substr = ft_substr(text, pos, 1 + special);
+	if (substr == NULL)
+	{
+		errno = ENOMEM;
+		return (NULL);
+	}
+	token = create_token(substr, type);
+	free(substr);
 	if (token == NULL)
 		errno = ENOMEM;
 	return (token);


### PR DESCRIPTION
• Added `free(envp[iteri])` and `free(envp)` in `src/base_commands/env.c` to prevent memory leaks during environment variable iteration.
• Introduced `substr` allocation and cleanup in `src/lexer/lexer_special.c` to handle token creation safely and avoid memory leaks.
• Improved error handling by setting `errno` to `ENOMEM` when memory allocation fails.
