### PR TITLE
solo builtin correction

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -20,6 +20,7 @@
 # include <stdint.h>
 
 # define NO_EXIT -1
+# define NO_INDEX 0
 
 typedef struct s_reader	t_reader;
 
@@ -74,7 +75,8 @@ typedef struct s_cmd
 	int					fd_infile;
 	int					fd_outfile;
 	int					**pipes;
-	int					fd[2];
+	int					stdin_backup;
+	int					stdout_backup;
 	char				**args;
 	char				**cmdpathlist;
 	char				*redirect_in;
@@ -113,6 +115,7 @@ int						ft_check_if_builtin(t_cmd *cmd, int cmd_idx);
 // pipex/ft_utils.c
 void					closefd(t_cmd *cmd, int exitnbr, t_reader *reader);
 void					ft_cleanup_cmd(t_cmd *cmd);
+void					ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp, t_reader *exit);
 int						ft_nbrofcmds(t_cmd *cmd);
 
 // pipex/ft_builtin.c

--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/25 11:03:33 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/21 14:51:41 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/22 16:18:33 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,24 +113,15 @@ static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp, t_reader *exit)
 	ft_wait_for_children(cmd[cmd->cmdnbr - 1].pid);
 }
 
-void	ft_pipex(t_cmd *cmd, t_list *tenvp, t_reader *exit)
+void ft_pipex(t_cmd *cmd, t_list *tenvp, t_reader *exit)
 {
 	cmd->error = 0;
 	cmd->cmdnbr = ft_nbrofcmds(cmd);
-	if (!ft_strncmp(cmd->args[0], "exit", 5) && cmd->cmdnbr == 1)
-		ft_exit(cmd->args, exit, NULL);
-	else if (!ft_strncmp(cmd->args[0], "cd", 3) && cmd->cmdnbr == 1)
-		ft_cd(cmd->args, &tenvp);
-	else if (!ft_strncmp(cmd->args[0], "export", 7) && cmd->cmdnbr == 1)
-		ft_export(cmd->args, &tenvp);
-	else if (!ft_strncmp(cmd->args[0], "unset", 6) && cmd->cmdnbr == 1)
-		ft_unset(cmd->args, &tenvp);
-	else if (!ft_strncmp(cmd->args[0], "pwd", 4) && cmd->cmdnbr == 1)
-		ft_pwd(&tenvp);
-	else if (!ft_strncmp(cmd->args[0], "env", 4) && cmd->cmdnbr == 1)
-		ft_env(&tenvp);
-	else if (!ft_strncmp(cmd->args[0], "echo", 5) && cmd->cmdnbr == 1)
-		ft_echo(cmd->argc, cmd->args);
+	cmd->stdin_backup = -1;
+	cmd->stdout_backup = -1;
+
+	if (cmd->cmdnbr == 1)
+		ft_exec_solobuiltin(cmd, &tenvp, exit);
 	else
 		fd_pipex_execute(cmd, tenvp, exit);
 	if (cmd->error != 0)

--- a/src/pipex/ft_utils.c
+++ b/src/pipex/ft_utils.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/01 13:34:25 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/21 16:09:19 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/22 16:18:15 by jfranc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,21 +71,47 @@ int	ft_nbrofcmds(t_cmd *cmd)
 	return (nbr);
 }
 
-void	*ft_realloc(void *ptr, size_t size)
+static void ft_dispatch_builtin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
 {
-	void	*new_ptr;
+    if (!ft_strncmp(cmd->args[0], "exit", 5))
+        ft_exit(cmd->args, exit, NULL);
+    else if (!ft_strncmp(cmd->args[0], "cd", 3))
+        ft_cd(cmd->args, tenvp);
+    else if (!ft_strncmp(cmd->args[0], "export", 7))
+        ft_export(cmd->args, tenvp);
+    else if (!ft_strncmp(cmd->args[0], "unset", 6))
+        ft_unset(cmd->args, tenvp);
+    else if (!ft_strncmp(cmd->args[0], "pwd", 4))
+        ft_pwd(tenvp);
+    else if (!ft_strncmp(cmd->args[0], "env", 4))
+        ft_env(tenvp);
+    else if (!ft_strncmp(cmd->args[0], "echo", 5))
+        ft_echo(cmd->argc, cmd->args);
+}
 
-	if (!ptr)
-		return (malloc(size));
-	if (size == 0)
-	{
-		free(ptr);
-		return (NULL);
-	}
-	new_ptr = malloc(size);
-	if (!new_ptr)
-		return (NULL);
-	ft_memcpy(new_ptr, ptr, size);
-	free(ptr);
-	return (new_ptr);
+void    ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
+{
+    if (cmd->fd_infile != STDIN_FILENO)
+    {
+        cmd->stdin_backup = dup(STDIN_FILENO); 
+        if (dup2(cmd->fd_infile, STDIN_FILENO) == -1)
+            perror("dup2 infile");
+    }
+    if (cmd->fd_outfile != STDOUT_FILENO)
+    {   
+        cmd->stdout_backup = dup(STDOUT_FILENO); 
+        if (dup2(cmd->fd_outfile, STDOUT_FILENO) == -1)
+            perror("dup2 outfile");
+    }
+    ft_dispatch_builtin(cmd, tenvp, exit);
+    if (cmd->stdin_backup != -1)
+    {
+        dup2(cmd->stdin_backup, STDIN_FILENO);
+        close(cmd->stdin_backup);
+    }
+    if (cmd->stdout_backup != -1)
+    {
+        dup2(cmd->stdout_backup, STDOUT_FILENO);
+        close(cmd->stdout_backup);
+    }
 }


### PR DESCRIPTION
This pull request refactors the handling of built-in commands in the `pipex` project, improving code organization and adding support for input/output redirection when executing single built-in commands. Key changes include the introduction of new helper functions, updates to the `t_cmd` structure, and a shift in how single built-in commands are executed.

### Refactoring and new functionality for built-in commands:
* Added a new function `ft_exec_solobuiltin` to handle the execution of single built-in commands with support for input/output redirection. This includes saving/restoring standard input/output file descriptors. (`include/shared.h` [[1]](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8R118) `src/pipex/ft_utils.c` [[2]](diffhunk://#diff-84111c506ecf619b3eb8156bd9562f14bdc732aec0d40b866fc7c1e42d806ef8L74-L90)
* Introduced a helper function `ft_dispatch_builtin` to centralize the logic for determining which built-in command to execute. (`src/pipex/ft_utils.c` [src/pipex/ft_utils.cL74-L90](diffhunk://#diff-84111c506ecf619b3eb8156bd9562f14bdc732aec0d40b866fc7c1e42d806ef8L74-L90))
* Updated `ft_pipex` to delegate the execution of single built-in commands to `ft_exec_solobuiltin`, simplifying the main logic. (`src/pipex/ft_pipex.c` [src/pipex/ft_pipex.cL120-R124](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cL120-R124))

### Structural updates:
* Modified the `t_cmd` structure to replace the `fd` array with `stdin_backup` and `stdout_backup`, enabling better management of file descriptor backups for redirection. (`include/shared.h` [include/shared.hL77-R79](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8L77-R79))

### Minor updates:
* Added a new constant `NO_INDEX` to `shared.h` for improved code clarity. (`include/shared.h` [include/shared.hR23](diffhunk://#diff-bd0afd749f2ac906e15f845428402377985477dd9ec43b29ee82256c4c5de0b8R23))
* Updated file metadata comments to reflect recent changes. (`src/pipex/ft_pipex.c` [[1]](diffhunk://#diff-151eadb4ed7364330848f3244173e53fef8789a2fe25e70100b64e0c316db91cL9-R9) `src/pipex/ft_utils.c` [[2]](diffhunk://#diff-84111c506ecf619b3eb8156bd9562f14bdc732aec0d40b866fc7c1e42d806ef8L9-R9)