### PR TITLE
refactor(builtins): Rework execution and env handling

### DIFF
--- a/.test/test_pwd.c
+++ b/.test/test_pwd.c
@@ -32,7 +32,7 @@ Test(pwd, prints_current_directory, .init = cr_redirect_stdout)
 	envp = NULL;
 	getcwd(cwd, sizeof(cwd));
 	b_setenv("PWD", cwd, &envp);
-	ft_pwd(&envp);
+	ft_pwd();
 	fflush(stdout);
 	snprintf(expected, sizeof(expected), "%s\n", cwd);
 	cr_assert_stdout_eq_str(expected);
@@ -44,7 +44,7 @@ Test(pwd, missing_pwd_env, .init = cr_redirect_stderr)
 	t_list	*envp;
 
 	envp = NULL;
-	ft_pwd(&envp);
+	ft_pwd();
 	fflush(stderr);
 	cr_assert_stderr_eq_str("pwd: error retrieving current directory\n");
 	ft_lstclear(&envp, free);
@@ -56,7 +56,7 @@ Test(pwd, empty_pwd_env, .init = cr_redirect_stdout)
 
 	envp = NULL;
 	b_setenv("PWD", "", &envp);
-	ft_pwd(&envp);
+	ft_pwd();
 	fflush(stdout);
 	cr_assert_stdout_eq_str("\n");
 	ft_lstclear(&envp, free);

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -18,220 +18,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcmp.o",
-      "src/memory/ft_memcmp.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memcmp.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcmp.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_tolower.o",
-      "src/ctype/ft_tolower.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_tolower.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_tolower.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/conversion/ft_itoa.o",
-      "src/conversion/ft_itoa.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/conversion/ft_itoa.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/conversion/ft_itoa.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
       "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalnum.o",
       "src/ctype/ft_isalnum.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
     "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isalnum.c",
     "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalnum.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_bzero.o",
-      "src/memory/ft_bzero.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_bzero.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_bzero.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memchr.o",
-      "src/memory/ft_memchr.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memchr.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memchr.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_calloc.o",
-      "src/memory/ft_calloc.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_calloc.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_calloc.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcpy.o",
-      "src/memory/ft_memcpy.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memcpy.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcpy.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalpha.o",
-      "src/ctype/ft_isalpha.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isalpha.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalpha.o"
   },
   {
     "arguments": [
@@ -278,32 +70,6 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_toupper.o",
-      "src/ctype/ft_toupper.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_toupper.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_toupper.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
       "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memset.o",
       "src/memory/ft_memset.c"
     ],
@@ -330,12 +96,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isascii.o",
-      "src/ctype/ft_isascii.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_toupper.o",
+      "src/ctype/ft_toupper.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isascii.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isascii.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_toupper.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_toupper.o"
   },
   {
     "arguments": [
@@ -356,12 +122,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isprint.o",
-      "src/ctype/ft_isprint.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcpy.o",
+      "src/memory/ft_memcpy.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isprint.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isprint.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memcpy.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcpy.o"
   },
   {
     "arguments": [
@@ -408,6 +174,32 @@
       "-Iinclude",
       "-c",
       "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isascii.o",
+      "src/ctype/ft_isascii.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isascii.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isascii.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
       "/home/creid/Documents/42/minishell/target/libft/build/conversion/ft_atoi.o",
       "src/conversion/ft_atoi.c"
     ],
@@ -434,12 +226,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strjoin.o",
-      "src/string/ft_strjoin.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_tolower.o",
+      "src/ctype/ft_tolower.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strjoin.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strjoin.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_tolower.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_tolower.o"
   },
   {
     "arguments": [
@@ -460,12 +252,194 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_substr.o",
-      "src/string/ft_substr.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcmp.o",
+      "src/memory/ft_memcmp.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_substr.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_substr.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memcmp.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memcmp.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalpha.o",
+      "src/ctype/ft_isalpha.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isalpha.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isalpha.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_calloc.o",
+      "src/memory/ft_calloc.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_calloc.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_calloc.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isprint.o",
+      "src/ctype/ft_isprint.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/ctype/ft_isprint.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/ctype/ft_isprint.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/conversion/ft_itoa.o",
+      "src/conversion/ft_itoa.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/conversion/ft_itoa.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/conversion/ft_itoa.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memchr.o",
+      "src/memory/ft_memchr.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_memchr.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_memchr.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_bzero.o",
+      "src/memory/ft_bzero.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/memory/ft_bzero.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/memory/ft_bzero.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlen.o",
+      "src/string/ft_strlen.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strlen.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlen.o"
   },
   {
     "arguments": [
@@ -512,12 +486,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strmapi.o",
-      "src/string/ft_strmapi.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strnstr.o",
+      "src/string/ft_strnstr.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strmapi.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strmapi.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strnstr.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strnstr.o"
   },
   {
     "arguments": [
@@ -538,12 +512,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strnstr.o",
-      "src/string/ft_strnstr.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strjoin.o",
+      "src/string/ft_strjoin.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strnstr.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strnstr.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strjoin.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strjoin.o"
   },
   {
     "arguments": [
@@ -616,38 +590,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlcpy.o",
-      "src/string/ft_strlcpy.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_substr.o",
+      "src/string/ft_substr.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strlcpy.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlcpy.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strdup.o",
-      "src/string/ft_strdup.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strdup.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strdup.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_substr.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_substr.o"
   },
   {
     "arguments": [
@@ -694,12 +642,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlen.o",
-      "src/string/ft_strlen.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_split.o",
+      "src/string/ft_split.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strlen.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlen.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_split.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_split.o"
   },
   {
     "arguments": [
@@ -720,38 +668,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_striteri.o",
-      "src/string/ft_striteri.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlcpy.o",
+      "src/string/ft_strlcpy.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_striteri.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_striteri.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstadd_back.o",
-      "src/list/ft_lstadd_back.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstadd_back.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstadd_back.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strlcpy.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strlcpy.o"
   },
   {
     "arguments": [
@@ -798,12 +720,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_split.o",
-      "src/string/ft_split.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strdup.o",
+      "src/string/ft_strdup.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_split.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_split.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strdup.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strdup.o"
   },
   {
     "arguments": [
@@ -850,12 +772,64 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstsize.o",
-      "src/list/ft_lstsize.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstadd_back.o",
+      "src/list/ft_lstadd_back.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstsize.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstsize.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstadd_back.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstadd_back.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_striteri.o",
+      "src/string/ft_striteri.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_striteri.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_striteri.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strmapi.o",
+      "src/string/ft_strmapi.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/string/ft_strmapi.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/string/ft_strmapi.o"
   },
   {
     "arguments": [
@@ -902,38 +876,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstnew.o",
-      "src/list/ft_lstnew.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstiter.o",
+      "src/list/ft_lstiter.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstnew.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstnew.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstlast.o",
-      "src/list/ft_lstlast.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstlast.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstlast.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstiter.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstiter.o"
   },
   {
     "arguments": [
@@ -1006,12 +954,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putendl_fd.o",
-      "src/fd/ft_putendl_fd.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstnew.o",
+      "src/list/ft_lstnew.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putendl_fd.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putendl_fd.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstnew.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstnew.o"
   },
   {
     "arguments": [
@@ -1032,12 +980,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstiter.o",
-      "src/list/ft_lstiter.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstsize.o",
+      "src/list/ft_lstsize.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstiter.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstiter.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstsize.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstsize.o"
   },
   {
     "arguments": [
@@ -1058,38 +1006,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putnbr_fd.o",
-      "src/fd/ft_putnbr_fd.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstlast.o",
+      "src/list/ft_lstlast.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putnbr_fd.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putnbr_fd.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./",
-      "-Iinclude",
-      "-c",
-      "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_printf.o",
-      "src/fd/ft_printf.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_printf.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_printf.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/list/ft_lstlast.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/list/ft_lstlast.o"
   },
   {
     "arguments": [
@@ -1136,12 +1058,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/utils/itoa.o",
-      "src/utils/itoa.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putendl_fd.o",
+      "src/fd/ft_putendl_fd.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/utils/itoa.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/utils/itoa.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putendl_fd.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putendl_fd.o"
   },
   {
     "arguments": [
@@ -1188,12 +1110,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/interface/hex.o",
-      "src/interface/hex.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putstr_fd.o",
+      "src/fd/ft_putstr_fd.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/interface/hex.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/interface/hex.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putstr_fd.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putstr_fd.o"
   },
   {
     "arguments": [
@@ -1214,12 +1136,12 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putstr_fd.o",
-      "src/fd/ft_putstr_fd.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/utils/itoa.o",
+      "src/utils/itoa.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putstr_fd.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putstr_fd.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/utils/itoa.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/utils/itoa.o"
   },
   {
     "arguments": [
@@ -1266,12 +1188,64 @@
       "-Iinclude",
       "-c",
       "-o",
-      "/home/creid/Documents/42/minishell/target/libft/build/interface/text.o",
-      "src/interface/text.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/interface/hex.o",
+      "src/interface/hex.c"
     ],
     "directory": "/home/creid/Documents/42/minishell/target/libft",
-    "file": "/home/creid/Documents/42/minishell/target/libft/src/interface/text.c",
-    "output": "/home/creid/Documents/42/minishell/target/libft/build/interface/text.o"
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/interface/hex.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/interface/hex.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_printf.o",
+      "src/fd/ft_printf.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_printf.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_printf.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./",
+      "-Iinclude",
+      "-c",
+      "-o",
+      "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putnbr_fd.o",
+      "src/fd/ft_putnbr_fd.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/fd/ft_putnbr_fd.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/fd/ft_putnbr_fd.o"
   },
   {
     "arguments": [
@@ -1314,15 +1288,16 @@
       "-ffunction-sections",
       "-fdata-sections",
       "-fno-exceptions",
-      "-I./target/criterion-2.4.2/include",
+      "-I./",
+      "-Iinclude",
       "-c",
       "-o",
-      "target/test/test_parser_pipe.o",
-      ".test/test_parser_pipe.c"
+      "/home/creid/Documents/42/minishell/target/libft/build/interface/text.o",
+      "src/interface/text.c"
     ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_parser_pipe.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_pipe.o"
+    "directory": "/home/creid/Documents/42/minishell/target/libft",
+    "file": "/home/creid/Documents/42/minishell/target/libft/src/interface/text.c",
+    "output": "/home/creid/Documents/42/minishell/target/libft/build/interface/text.o"
   },
   {
     "arguments": [
@@ -1342,37 +1317,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_b_unsetenv.o",
-      ".test/test_b_unsetenv.c"
+      "target/test/test_lexer_quotes.o",
+      ".test/test_lexer_quotes.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_b_unsetenv.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_b_unsetenv.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./target/criterion-2.4.2/include",
-      "-c",
-      "-o",
-      "target/test/test_utils.o",
-      ".test/test_utils.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_utils.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_utils.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_quotes.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_quotes.o"
   },
   {
     "arguments": [
@@ -1398,6 +1348,56 @@
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/.test/test_lexer_basic.c",
     "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_basic.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_b_fromenvp.o",
+      ".test/test_b_fromenvp.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_fromenvp.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_fromenvp.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_parser_basic.o",
+      ".test/test_parser_basic.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_parser_basic.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_basic.o"
   },
   {
     "arguments": [
@@ -1492,12 +1492,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_b_fromenvp.o",
-      ".test/test_b_fromenvp.c"
+      "target/test/test_utils.o",
+      ".test/test_utils.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_b_fromenvp.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_b_fromenvp.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_utils.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_utils.o"
   },
   {
     "arguments": [
@@ -1542,37 +1542,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_join_words.o",
-      ".test/test_join_words.c"
+      "target/test/test_parser_pipe.o",
+      ".test/test_parser_pipe.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_join_words.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_join_words.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-I./target/criterion-2.4.2/include",
-      "-c",
-      "-o",
-      "target/test/test_lexer_redirections.o",
-      ".test/test_lexer_redirections.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_redirections.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_redirections.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_parser_pipe.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_pipe.o"
   },
   {
     "arguments": [
@@ -1617,12 +1592,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_lexer_quotes.o",
-      ".test/test_lexer_quotes.c"
+      "target/test/test_join_words.o",
+      ".test/test_join_words.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_quotes.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_quotes.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_join_words.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_join_words.o"
   },
   {
     "arguments": [
@@ -1642,12 +1617,37 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_parser_basic.o",
-      ".test/test_parser_basic.c"
+      "target/test/test_b_unsetenv.o",
+      ".test/test_b_unsetenv.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_parser_basic.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_parser_basic.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_b_unsetenv.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_b_unsetenv.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-I./target/criterion-2.4.2/include",
+      "-c",
+      "-o",
+      "target/test/test_lexer_redirections.o",
+      ".test/test_lexer_redirections.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/.test/test_lexer_redirections.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_lexer_redirections.o"
   },
   {
     "arguments": [
@@ -1716,12 +1716,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/process_variable_expansion.o",
-      "src/process_variable_expansion.c"
+      "target/main_extra.o",
+      "src/main_extra.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/process_variable_expansion.c",
-    "output": "/home/creid/Documents/42/minishell/target/process_variable_expansion.o"
+    "file": "/home/creid/Documents/42/minishell/src/main_extra.c",
+    "output": "/home/creid/Documents/42/minishell/target/main_extra.o"
   },
   {
     "arguments": [
@@ -1788,30 +1788,6 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/init_shell.o",
-      "src/init_shell.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/init_shell.c",
-    "output": "/home/creid/Documents/42/minishell/target/init_shell.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
       "target/build_varnames_array.o",
       "src/build_varnames_array.c"
     ],
@@ -1836,60 +1812,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/read_input.o",
-      "src/read_input.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/read_input.c",
-    "output": "/home/creid/Documents/42/minishell/target/read_input.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
       "target/print_tokens.o",
       "src/print_tokens.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/print_tokens.c",
     "output": "/home/creid/Documents/42/minishell/target/print_tokens.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/main_extra.o",
-      "src/main_extra.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/main_extra.c",
-    "output": "/home/creid/Documents/42/minishell/target/main_extra.o"
   },
   {
     "arguments": [
@@ -1954,15 +1882,14 @@
       "-ffunction-sections",
       "-fdata-sections",
       "-fno-exceptions",
-      "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_env.o",
-      ".test/test_env.c"
+      "target/init_shell.o",
+      "src/init_shell.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_env.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_env.o"
+    "file": "/home/creid/Documents/42/minishell/src/init_shell.c",
+    "output": "/home/creid/Documents/42/minishell/target/init_shell.o"
   },
   {
     "arguments": [
@@ -1979,15 +1906,14 @@
       "-ffunction-sections",
       "-fdata-sections",
       "-fno-exceptions",
-      "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_unset.o",
-      ".test/test_unset.c"
+      "target/read_input.o",
+      "src/read_input.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_unset.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_unset.o"
+    "file": "/home/creid/Documents/42/minishell/src/read_input.c",
+    "output": "/home/creid/Documents/42/minishell/target/read_input.o"
   },
   {
     "arguments": [
@@ -2032,12 +1958,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_export.o",
-      ".test/test_export.c"
+      "target/test/test_exit.o",
+      ".test/test_exit.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_export.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_export.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_exit.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_exit.o"
   },
   {
     "arguments": [
@@ -2082,12 +2008,12 @@
       "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/test/test_exit.o",
-      ".test/test_exit.c"
+      "target/test/test_env.o",
+      ".test/test_env.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/.test/test_exit.c",
-    "output": "/home/creid/Documents/42/minishell/target/test/test_exit.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_env.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_env.o"
   },
   {
     "arguments": [
@@ -2106,12 +2032,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/lexer/run_lexer.o",
-      "src/lexer/run_lexer.c"
+      "target/process_variable_expansion.o",
+      "src/process_variable_expansion.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/lexer/run_lexer.c",
-    "output": "/home/creid/Documents/42/minishell/target/lexer/run_lexer.o"
+    "file": "/home/creid/Documents/42/minishell/src/process_variable_expansion.c",
+    "output": "/home/creid/Documents/42/minishell/target/process_variable_expansion.o"
   },
   {
     "arguments": [
@@ -2128,14 +2054,15 @@
       "-ffunction-sections",
       "-fdata-sections",
       "-fno-exceptions",
+      "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/lexer/create_lexer.o",
-      "src/lexer/create_lexer.c"
+      "target/test/test_export.o",
+      ".test/test_export.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/lexer/create_lexer.c",
-    "output": "/home/creid/Documents/42/minishell/target/lexer/create_lexer.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_export.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_export.o"
   },
   {
     "arguments": [
@@ -2152,38 +2079,15 @@
       "-ffunction-sections",
       "-fdata-sections",
       "-fno-exceptions",
+      "-I./target/criterion-2.4.2/include",
       "-c",
       "-o",
-      "target/cleanup_shell.o",
-      "src/cleanup_shell.c"
+      "target/test/test_unset.o",
+      ".test/test_unset.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/cleanup_shell.c",
-    "output": "/home/creid/Documents/42/minishell/target/cleanup_shell.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/process_commands.o",
-      "src/process_commands.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/process_commands.c",
-    "output": "/home/creid/Documents/42/minishell/target/process_commands.o"
+    "file": "/home/creid/Documents/42/minishell/.test/test_unset.c",
+    "output": "/home/creid/Documents/42/minishell/target/test/test_unset.o"
   },
   {
     "arguments": [
@@ -2226,12 +2130,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/cleanup_iteration.o",
-      "src/cleanup_iteration.c"
+      "target/process_commands.o",
+      "src/process_commands.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/cleanup_iteration.c",
-    "output": "/home/creid/Documents/42/minishell/target/cleanup_iteration.o"
+    "file": "/home/creid/Documents/42/minishell/src/process_commands.c",
+    "output": "/home/creid/Documents/42/minishell/target/process_commands.o"
   },
   {
     "arguments": [
@@ -2298,6 +2202,30 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/cleanup_iteration.o",
+      "src/cleanup_iteration.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/cleanup_iteration.c",
+    "output": "/home/creid/Documents/42/minishell/target/cleanup_iteration.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/lexer/free_lexer.o",
       "src/lexer/free_lexer.c"
     ],
@@ -2322,12 +2250,84 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/cleanup_shell.o",
+      "src/cleanup_shell.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/cleanup_shell.c",
+    "output": "/home/creid/Documents/42/minishell/target/cleanup_shell.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/lexer/create_lexer.o",
+      "src/lexer/create_lexer.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/lexer/create_lexer.c",
+    "output": "/home/creid/Documents/42/minishell/target/lexer/create_lexer.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/lexer/join_words.o",
       "src/lexer/join_words.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/lexer/join_words.c",
     "output": "/home/creid/Documents/42/minishell/target/lexer/join_words.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/lexer/run_lexer.o",
+      "src/lexer/run_lexer.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/lexer/run_lexer.c",
+    "output": "/home/creid/Documents/42/minishell/target/lexer/run_lexer.o"
   },
   {
     "arguments": [
@@ -2442,12 +2442,84 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/lexer/end_token.o",
+      "src/lexer/end_token.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/lexer/end_token.c",
+    "output": "/home/creid/Documents/42/minishell/target/lexer/end_token.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/lexer/lexer_special.o",
       "src/lexer/lexer_special.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/lexer/lexer_special.c",
     "output": "/home/creid/Documents/42/minishell/target/lexer/lexer_special.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/b_varexists.o",
+      "src/utils/b_varexists.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/b_varexists.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/b_varexists.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/b_fromenvp.o",
+      "src/utils/b_fromenvp.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/b_fromenvp.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/b_fromenvp.o"
   },
   {
     "arguments": [
@@ -2514,12 +2586,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/b_fromenvp.o",
-      "src/utils/b_fromenvp.c"
+      "target/utils/b_setenv.o",
+      "src/utils/b_setenv.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/b_fromenvp.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/b_fromenvp.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/b_setenv.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/b_setenv.o"
   },
   {
     "arguments": [
@@ -2544,102 +2616,6 @@
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/utils/b_getenv.c",
     "output": "/home/creid/Documents/42/minishell/target/utils/b_getenv.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/ft_readline.o",
-      "src/utils/ft_readline.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readline.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readline.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/lexer/end_token.o",
-      "src/lexer/end_token.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/lexer/end_token.c",
-    "output": "/home/creid/Documents/42/minishell/target/lexer/end_token.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/b_varexists.o",
-      "src/utils/b_varexists.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/b_varexists.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/b_varexists.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/b_setenv.o",
-      "src/utils/b_setenv.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/b_setenv.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/b_setenv.o"
   },
   {
     "arguments": [
@@ -2730,12 +2706,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/ft_readint.o",
-      "src/utils/ft_readint.c"
+      "target/utils/ft_readline.o",
+      "src/utils/ft_readline.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readint.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readint.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readline.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readline.o"
   },
   {
     "arguments": [
@@ -2778,12 +2754,132 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/ft_opentmp.o",
-      "src/utils/ft_opentmp.c"
+      "target/utils/ft_readint.o",
+      "src/utils/ft_readint.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_opentmp.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_opentmp.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readint.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readint.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_readlong.o",
+      "src/utils/ft_readlong.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readlong.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readlong.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_readuint.o",
+      "src/utils/ft_readuint.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readuint.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readuint.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_readullong.o",
+      "src/utils/ft_readullong.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readullong.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readullong.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_readlonglong.o",
+      "src/utils/ft_readlonglong.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readlonglong.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readlonglong.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_readulong.o",
+      "src/utils/ft_readulong.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readulong.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readulong.o"
   },
   {
     "arguments": [
@@ -2874,108 +2970,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/ft_readulong.o",
-      "src/utils/ft_readulong.c"
+      "target/utils/var/handle_special_var.o",
+      "src/utils/var/handle_special_var.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readulong.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readulong.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/ft_readuint.o",
-      "src/utils/ft_readuint.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readuint.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readuint.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/ft_readlonglong.o",
-      "src/utils/ft_readlonglong.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readlonglong.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readlonglong.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/ft_readullong.o",
-      "src/utils/ft_readullong.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readullong.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readullong.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/ft_readlong.o",
-      "src/utils/ft_readlong.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/ft_readlong.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/ft_readlong.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_special_var.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_special_var.o"
   },
   {
     "arguments": [
@@ -3000,6 +3000,78 @@
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/utils/var/b_getenv_one.c",
     "output": "/home/creid/Documents/42/minishell/target/utils/var/b_getenv_one.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/ft_opentmp.o",
+      "src/utils/ft_opentmp.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/ft_opentmp.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/ft_opentmp.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/var/count_unmatched_var.o",
+      "src/utils/var/count_unmatched_var.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/count_unmatched_var.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/count_unmatched_var.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/var/ft_strcpy.o",
+      "src/utils/var/ft_strcpy.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/ft_strcpy.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/ft_strcpy.o"
   },
   {
     "arguments": [
@@ -3066,12 +3138,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/handle_special_var.o",
-      "src/utils/var/handle_special_var.c"
+      "target/utils/var/expand_unmatched_var.o",
+      "src/utils/var/expand_unmatched_var.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_special_var.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_special_var.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/expand_unmatched_var.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/expand_unmatched_var.o"
   },
   {
     "arguments": [
@@ -3090,12 +3162,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/ft_strcpy.o",
-      "src/utils/var/ft_strcpy.c"
+      "target/utils/var/expand_special_var.o",
+      "src/utils/var/expand_special_var.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/ft_strcpy.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/ft_strcpy.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/expand_special_var.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/expand_special_var.o"
   },
   {
     "arguments": [
@@ -3114,12 +3186,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/count_unmatched_var.o",
-      "src/utils/var/count_unmatched_var.c"
+      "target/utils/var/iskey.o",
+      "src/utils/var/iskey.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/count_unmatched_var.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/count_unmatched_var.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/iskey.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/iskey.o"
   },
   {
     "arguments": [
@@ -3138,12 +3210,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/handle_var_expansion.o",
-      "src/utils/var/handle_var_expansion.c"
+      "target/utils/var/num_places.o",
+      "src/utils/var/num_places.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_var_expansion.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_var_expansion.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/num_places.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/num_places.o"
   },
   {
     "arguments": [
@@ -3162,12 +3234,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/replace_backspace_with_dollar.o",
-      "src/utils/var/replace_backspace_with_dollar.c"
+      "target/utils/var/handle_regular_char.o",
+      "src/utils/var/handle_regular_char.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/replace_backspace_with_dollar.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/replace_backspace_with_dollar.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_regular_char.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_regular_char.o"
   },
   {
     "arguments": [
@@ -3210,12 +3282,36 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/num_places.o",
-      "src/utils/var/num_places.c"
+      "target/utils/var/handle_var_expansion.o",
+      "src/utils/var/handle_var_expansion.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/num_places.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/num_places.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_var_expansion.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_var_expansion.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/utils/var/handle_dollar_substitution.o",
+      "src/utils/var/handle_dollar_substitution.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_dollar_substitution.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_dollar_substitution.o"
   },
   {
     "arguments": [
@@ -3282,12 +3378,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/expand_unmatched_var.o",
-      "src/utils/var/expand_unmatched_var.c"
+      "target/utils/var/replace_backspace_with_dollar.o",
+      "src/utils/var/replace_backspace_with_dollar.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/expand_unmatched_var.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/expand_unmatched_var.o"
+    "file": "/home/creid/Documents/42/minishell/src/utils/var/replace_backspace_with_dollar.c",
+    "output": "/home/creid/Documents/42/minishell/target/utils/var/replace_backspace_with_dollar.o"
   },
   {
     "arguments": [
@@ -3306,12 +3402,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/iskey.o",
-      "src/utils/var/iskey.c"
+      "target/parser/p_strerror.o",
+      "src/parser/p_strerror.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/iskey.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/iskey.o"
+    "file": "/home/creid/Documents/42/minishell/src/parser/p_strerror.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/p_strerror.o"
   },
   {
     "arguments": [
@@ -3330,60 +3426,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/utils/var/expand_special_var.o",
-      "src/utils/var/expand_special_var.c"
+      "target/parser/parser_init.o",
+      "src/parser/parser_init.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/expand_special_var.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/expand_special_var.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/var/handle_regular_char.o",
-      "src/utils/var/handle_regular_char.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_regular_char.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_regular_char.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/utils/var/handle_dollar_substitution.o",
-      "src/utils/var/handle_dollar_substitution.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/utils/var/handle_dollar_substitution.c",
-    "output": "/home/creid/Documents/42/minishell/target/utils/var/handle_dollar_substitution.o"
+    "file": "/home/creid/Documents/42/minishell/src/parser/parser_init.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/parser_init.o"
   },
   {
     "arguments": [
@@ -3450,108 +3498,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/parser/parser_init.o",
-      "src/parser/parser_init.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/parser_init.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/parser_init.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/parser/p_strerror.o",
-      "src/parser/p_strerror.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/p_strerror.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/p_strerror.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/parser/parser_special_pipe.o",
-      "src/parser/parser_special_pipe.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/parser_special_pipe.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/parser_special_pipe.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
       "target/parser/parser_to_list.o",
       "src/parser/parser_to_list.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/parser/parser_to_list.c",
     "output": "/home/creid/Documents/42/minishell/target/parser/parser_to_list.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/parser/parser_special_redirect_in.o",
-      "src/parser/parser_special_redirect_in.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/parser_special_redirect_in.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/parser_special_redirect_in.o"
   },
   {
     "arguments": [
@@ -3618,6 +3570,30 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/parser/parser_special_pipe.o",
+      "src/parser/parser_special_pipe.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/parser/parser_special_pipe.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/parser_special_pipe.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/parser/parser_special_redirect_append.o",
       "src/parser/parser_special_redirect_append.c"
     ],
@@ -3666,36 +3642,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/parser/get_redirect_token.o",
-      "src/parser/get_redirect_token.c"
+      "target/parser/parser_special_redirect_in.o",
+      "src/parser/parser_special_redirect_in.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/get_redirect_token.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/get_redirect_token.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/parser/end_command.o",
-      "src/parser/end_command.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/parser/end_command.c",
-    "output": "/home/creid/Documents/42/minishell/target/parser/end_command.o"
+    "file": "/home/creid/Documents/42/minishell/src/parser/parser_special_redirect_in.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/parser_special_redirect_in.o"
   },
   {
     "arguments": [
@@ -3738,60 +3690,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/base_commands/cd.o",
-      "src/base_commands/cd.c"
+      "target/parser/get_redirect_token.o",
+      "src/parser/get_redirect_token.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/cd.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/cd.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/base_commands/exit.o",
-      "src/base_commands/exit.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/exit.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/exit.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/base_commands/env.o",
-      "src/base_commands/env.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/env.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/env.o"
+    "file": "/home/creid/Documents/42/minishell/src/parser/get_redirect_token.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/get_redirect_token.o"
   },
   {
     "arguments": [
@@ -3834,12 +3738,36 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/base_commands/pwd.o",
-      "src/base_commands/pwd.c"
+      "target/parser/end_command.o",
+      "src/parser/end_command.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/pwd.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/pwd.o"
+    "file": "/home/creid/Documents/42/minishell/src/parser/end_command.c",
+    "output": "/home/creid/Documents/42/minishell/target/parser/end_command.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/base_commands/cd.o",
+      "src/base_commands/cd.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/cd.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/cd.o"
   },
   {
     "arguments": [
@@ -3882,6 +3810,78 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/base_commands/pwd.o",
+      "src/base_commands/pwd.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/pwd.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/pwd.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/base_commands/env.o",
+      "src/base_commands/env.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/env.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/env.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/base_commands/exit.o",
+      "src/base_commands/exit.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/exit.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/exit.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/base_commands/export.o",
       "src/base_commands/export.c"
     ],
@@ -3906,12 +3906,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/base_commands/export/is_valid_identifier.o",
-      "src/base_commands/export/is_valid_identifier.c"
+      "target/base_commands/unset.o",
+      "src/base_commands/unset.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/export/is_valid_identifier.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/export/is_valid_identifier.o"
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/unset.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/unset.o"
   },
   {
     "arguments": [
@@ -3930,12 +3930,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/base_commands/unset.o",
-      "src/base_commands/unset.c"
+      "target/base_commands/export/is_valid_identifier.o",
+      "src/base_commands/export/is_valid_identifier.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/unset.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/unset.o"
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/export/is_valid_identifier.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/export/is_valid_identifier.o"
   },
   {
     "arguments": [
@@ -4002,30 +4002,6 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/base_commands/export/export_variable.o",
-      "src/base_commands/export/export_variable.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/base_commands/export/export_variable.c",
-    "output": "/home/creid/Documents/42/minishell/target/base_commands/export/export_variable.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
       "target/base_commands/export/export_without_value.o",
       "src/base_commands/export/export_without_value.c"
     ],
@@ -4074,12 +4050,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/reader/try_read.o",
-      "src/reader/try_read.c"
+      "target/base_commands/export/export_variable.o",
+      "src/base_commands/export/export_variable.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/reader/try_read.c",
-    "output": "/home/creid/Documents/42/minishell/target/reader/try_read.o"
+    "file": "/home/creid/Documents/42/minishell/src/base_commands/export/export_variable.c",
+    "output": "/home/creid/Documents/42/minishell/target/base_commands/export/export_variable.o"
   },
   {
     "arguments": [
@@ -4122,12 +4098,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/reader/try_lex.o",
-      "src/reader/try_lex.c"
+      "target/reader/handle_read.o",
+      "src/reader/handle_read.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/reader/try_lex.c",
-    "output": "/home/creid/Documents/42/minishell/target/reader/try_lex.o"
+    "file": "/home/creid/Documents/42/minishell/src/reader/handle_read.c",
+    "output": "/home/creid/Documents/42/minishell/target/reader/handle_read.o"
   },
   {
     "arguments": [
@@ -4146,12 +4122,36 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/reader/handle_read.o",
-      "src/reader/handle_read.c"
+      "target/reader/try_read.o",
+      "src/reader/try_read.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/reader/handle_read.c",
-    "output": "/home/creid/Documents/42/minishell/target/reader/handle_read.o"
+    "file": "/home/creid/Documents/42/minishell/src/reader/try_read.c",
+    "output": "/home/creid/Documents/42/minishell/target/reader/try_read.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/reader/try_lex.o",
+      "src/reader/try_lex.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/reader/try_lex.c",
+    "output": "/home/creid/Documents/42/minishell/target/reader/try_lex.o"
   },
   {
     "arguments": [
@@ -4242,12 +4242,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/pipex/cmd_path.o",
-      "src/pipex/cmd_path.c"
+      "target/pipex/ft_pipex.o",
+      "src/pipex/ft_pipex.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/pipex/cmd_path.c",
-    "output": "/home/creid/Documents/42/minishell/target/pipex/cmd_path.o"
+    "file": "/home/creid/Documents/42/minishell/src/pipex/ft_pipex.c",
+    "output": "/home/creid/Documents/42/minishell/target/pipex/ft_pipex.o"
   },
   {
     "arguments": [
@@ -4266,12 +4266,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/pipex/ft_pipex.o",
-      "src/pipex/ft_pipex.c"
+      "target/pipex/cmd_path.o",
+      "src/pipex/cmd_path.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/pipex/ft_pipex.c",
-    "output": "/home/creid/Documents/42/minishell/target/pipex/ft_pipex.o"
+    "file": "/home/creid/Documents/42/minishell/src/pipex/cmd_path.c",
+    "output": "/home/creid/Documents/42/minishell/target/pipex/cmd_path.o"
   },
   {
     "arguments": [
@@ -4338,12 +4338,36 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/pipex/ft_builtin.o",
-      "src/pipex/ft_builtin.c"
+      "target/git/read_head_file.o",
+      "src/git/read_head_file.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/pipex/ft_builtin.c",
-    "output": "/home/creid/Documents/42/minishell/target/pipex/ft_builtin.o"
+    "file": "/home/creid/Documents/42/minishell/src/git/read_head_file.c",
+    "output": "/home/creid/Documents/42/minishell/target/git/read_head_file.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/git/find_git_dir.o",
+      "src/git/find_git_dir.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/git/find_git_dir.c",
+    "output": "/home/creid/Documents/42/minishell/target/git/find_git_dir.o"
   },
   {
     "arguments": [
@@ -4410,60 +4434,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/git/find_git_dir.o",
-      "src/git/find_git_dir.c"
+      "target/pipex/ft_builtin.o",
+      "src/pipex/ft_builtin.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/git/find_git_dir.c",
-    "output": "/home/creid/Documents/42/minishell/target/git/find_git_dir.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/git/get_branch_name.o",
-      "src/git/get_branch_name.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/git/get_branch_name.c",
-    "output": "/home/creid/Documents/42/minishell/target/git/get_branch_name.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/git/read_head_file.o",
-      "src/git/read_head_file.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/git/read_head_file.c",
-    "output": "/home/creid/Documents/42/minishell/target/git/read_head_file.o"
+    "file": "/home/creid/Documents/42/minishell/src/pipex/ft_builtin.c",
+    "output": "/home/creid/Documents/42/minishell/target/pipex/ft_builtin.o"
   },
   {
     "arguments": [
@@ -4506,6 +4482,30 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/git/get_branch_name.o",
+      "src/git/get_branch_name.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/git/get_branch_name.c",
+    "output": "/home/creid/Documents/42/minishell/target/git/get_branch_name.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/git/git_getbranch.o",
       "src/git/git_getbranch.c"
     ],
@@ -4530,60 +4530,12 @@
       "-fno-exceptions",
       "-c",
       "-o",
-      "target/git/is_git_changes_staged.o",
-      "src/git/is_git_changes_staged.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/git/is_git_changes_staged.c",
-    "output": "/home/creid/Documents/42/minishell/target/git/is_git_changes_staged.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
       "target/git/is_git_changes.o",
       "src/git/is_git_changes.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/git/is_git_changes.c",
     "output": "/home/creid/Documents/42/minishell/target/git/is_git_changes.o"
-  },
-  {
-    "arguments": [
-      "/usr/lib64/ccache/cc",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-std=gnu17",
-      "-I./include",
-      "-pipe",
-      "-I./target/libft/",
-      "-Os",
-      "-flto",
-      "-ffunction-sections",
-      "-fdata-sections",
-      "-fno-exceptions",
-      "-c",
-      "-o",
-      "target/sigint/sigint_handler.o",
-      "src/sigint/sigint_handler.c"
-    ],
-    "directory": "/home/creid/Documents/42/minishell",
-    "file": "/home/creid/Documents/42/minishell/src/sigint/sigint_handler.c",
-    "output": "/home/creid/Documents/42/minishell/target/sigint/sigint_handler.o"
   },
   {
     "arguments": [
@@ -4650,11 +4602,59 @@
       "-fno-exceptions",
       "-c",
       "-o",
+      "target/git/is_git_changes_staged.o",
+      "src/git/is_git_changes_staged.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/git/is_git_changes_staged.c",
+    "output": "/home/creid/Documents/42/minishell/target/git/is_git_changes_staged.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
       "target/main.o",
       "src/main.c"
     ],
     "directory": "/home/creid/Documents/42/minishell",
     "file": "/home/creid/Documents/42/minishell/src/main.c",
     "output": "/home/creid/Documents/42/minishell/target/main.o"
+  },
+  {
+    "arguments": [
+      "/usr/lib64/ccache/cc",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-std=gnu17",
+      "-I./include",
+      "-pipe",
+      "-I./target/libft/",
+      "-Os",
+      "-flto",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-fno-exceptions",
+      "-c",
+      "-o",
+      "target/sigint/sigint_handler.o",
+      "src/sigint/sigint_handler.c"
+    ],
+    "directory": "/home/creid/Documents/42/minishell",
+    "file": "/home/creid/Documents/42/minishell/src/sigint/sigint_handler.c",
+    "output": "/home/creid/Documents/42/minishell/target/sigint/sigint_handler.o"
   }
 ]

--- a/include/main_extra.h
+++ b/include/main_extra.h
@@ -11,31 +11,31 @@
 /* ************************************************************************** */
 
 #ifndef MAIN_EXTRA_H
-# define MAIN_EXTRA_H
+#define MAIN_EXTRA_H
 
-# include "libft.h"
-# include "parser.h"
-# include "shared.h"
+#include "libft.h"
+#include "parser.h"
+#include "shared.h"
 
 /// @brief Prints all tokens in a token list for debugging
 /// @param tokens Linked list of tokens to print
-void	print_tokens(t_list *tokens);
+void print_tokens(t_list *tokens);
 
 /// @brief Prints command details for debugging
 /// @param cmd Pointer to the command structure to print
-void	ft_prints(t_cmd *cmd);
+void ft_prints(t_cmd *cmd);
 
 /// @brief Prints parser state and command list for debugging
 /// @param parser Pointer to the parser structure to print
-void	print_parser(t_parser *parser);
+void print_parser(t_parser *parser);
 
 /// @brief Processes heredoc input for parsed commands
 /// @param cmds Array of commands to process heredocs for
 /// @param env Environment list (currently unused)
-void	process_heredocs(t_cmd *cmds, t_list *env);
+void process_heredocs(t_cmd *cmds);
 
-t_cmd	*remove_empty_commands(t_cmd *commands);
+t_cmd *remove_empty_commands(t_cmd *commands);
 
-void	print_parser(t_parser *parser);
+void print_parser(t_parser *parser);
 
 #endif

--- a/include/shared.h
+++ b/include/shared.h
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:24:32 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/22 13:42:13 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/23 11:52:23 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,7 +115,8 @@ int						ft_check_if_builtin(t_cmd *cmd, int cmd_idx);
 // pipex/ft_utils.c
 void					closefd(t_cmd *cmd, int exitnbr, t_reader *reader);
 void					ft_cleanup_cmd(t_cmd *cmd);
-void					ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp, t_reader *exit);
+void					ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp,
+							t_reader *exit);
 int						ft_nbrofcmds(t_cmd *cmd);
 
 // pipex/ft_builtin.c
@@ -128,7 +129,7 @@ void					ft_echo(int argc, char **argv);
 void					ft_env(t_list **env);
 void					ft_exit(char **s, t_reader *reader, t_cmd **cmd);
 void					ft_export(char **argv, t_list **envp);
-void					ft_pwd(t_list **envp);
+void					ft_pwd(void);
 void					ft_unset(char **args, t_list **envp);
 
 #endif

--- a/src/base_commands/pwd.c
+++ b/src/base_commands/pwd.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 11:55:23 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/09 11:07:45 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/23 11:52:33 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,16 +16,14 @@
 #include <string.h>
 #include <unistd.h>
 
-void	ft_pwd(t_list **envp)
+void	ft_pwd(void)
 {
-	char	**pwd;
+	char	pwd[420];
 
-	pwd = b_getenv("PWD", *envp);
-	if (pwd && pwd[0])
+	getcwd(pwd, 419);
+	if (pwd[0])
 	{
-		printf("%s\n", pwd[0]);
-		free(pwd[0]);
-		free(pwd);
+		printf("%s\n", pwd);
 		g_status_code = 0;
 	}
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 14:49:10 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/17 10:41:57 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/23 11:53:38 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,20 @@
 #include "varextract.h"
 #include <readline/history.h>
 #include <readline/readline.h>
+#include <string.h>
 #include <unistd.h>
+
+void	default_env(t_reader *reader)
+{
+		char cwd[420];
+
+	if (reader->env == NULL)
+	{
+		getcwd(cwd, 419);
+		b_setenv("PWD", cwd, &reader->env);
+		b_setenv("SHLVL", "1", &reader->env);
+	}
+}
 
 int	main(int argc, char **argv, char **envp)
 {
@@ -27,6 +40,7 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	(void)argv;
 	reader_ptr = init_shell(envp);
+	default_env(reader_ptr);
 	while (1)
 	{
 		input_status = read_input(reader_ptr);

--- a/src/main_extra.c
+++ b/src/main_extra.c
@@ -10,8 +10,8 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "libft.h"
 #include "main_extra.h"
+#include "libft.h"
 #include "parser.h"
 #include "reader.h"
 #include "shared.h"
@@ -21,116 +21,101 @@
 #include <unistd.h>
 
 // Helper function to find the last delimiter in the list
-static char	*find_last_delimiter(t_list *heredoc_delimiters)
-{
-	t_list	*delim_node;
-	char	*last_delimiter;
+static char *find_last_delimiter(t_list *heredoc_delimiters) {
+  t_list *delim_node;
+  char *last_delimiter;
 
-	delim_node = heredoc_delimiters;
-	last_delimiter = NULL;
-	while (delim_node)
-	{
-		last_delimiter = (char *)delim_node->content;
-		delim_node = delim_node->next;
-	}
-	return (last_delimiter);
+  delim_node = heredoc_delimiters;
+  last_delimiter = NULL;
+  while (delim_node) {
+    last_delimiter = (char *)delim_node->content;
+    delim_node = delim_node->next;
+  }
+  return (last_delimiter);
 }
 
 // Helper function to read heredoc input until delimiter is found
-static void	read_heredoc_input(char *delimiter, t_file *tmpf,
-		bool write_to_file)
-{
-	char	*line;
+static void read_heredoc_input(char *delimiter, t_file *tmpf,
+                               bool write_to_file) {
+  char *line;
 
-	while (true)
-	{
-		line = readline("heredoc> ");
-		if (!line)
-			break ;
-		if (ft_strncmp(line, delimiter, ft_strlen(delimiter)) == 0
-			&& ft_strlen(line) == ft_strlen(delimiter))
-		{
-			free(line);
-			break ;
-		}
-		if (write_to_file && tmpf)
-		{
-			ft_putstr_fd(line, tmpf->fd);
-			ft_putstr_fd("\n", tmpf->fd);
-		}
-		free(line);
-	}
+  while (true) {
+    line = readline("heredoc> ");
+    if (!line)
+      break;
+    if (ft_strncmp(line, delimiter, ft_strlen(delimiter)) == 0 &&
+        ft_strlen(line) == ft_strlen(delimiter)) {
+      free(line);
+      break;
+    }
+    if (write_to_file && tmpf) {
+      ft_putstr_fd(line, tmpf->fd);
+      ft_putstr_fd("\n", tmpf->fd);
+    }
+    free(line);
+  }
 }
 
 // Helper function to process all heredoc delimiters for a command
-static t_file	*process_heredoc_delimiters(t_list *heredoc_delimiters)
-{
-	t_list	*delim_node;
-	char	*delimiter;
-	char	*last_delimiter;
-	t_file	*tmpf;
+static t_file *process_heredoc_delimiters(t_list *heredoc_delimiters) {
+  t_list *delim_node;
+  char *delimiter;
+  char *last_delimiter;
+  t_file *tmpf;
 
-	last_delimiter = find_last_delimiter(heredoc_delimiters);
-	tmpf = NULL;
-	delim_node = heredoc_delimiters;
-	while (delim_node)
-	{
-		delimiter = (char *)delim_node->content;
-		if (delimiter == last_delimiter)
-		{
-			tmpf = ft_opentmp(ft_openurand(), true);
-			if (!tmpf)
-			{
-				perror("heredoc");
-				break ;
-			}
-		}
-		read_heredoc_input(delimiter, tmpf, delimiter == last_delimiter);
-		delim_node = delim_node->next;
-	}
-	return (tmpf);
+  last_delimiter = find_last_delimiter(heredoc_delimiters);
+  tmpf = NULL;
+  delim_node = heredoc_delimiters;
+  while (delim_node) {
+    delimiter = (char *)delim_node->content;
+    if (delimiter == last_delimiter) {
+      tmpf = ft_opentmp(ft_openurand(), true);
+      if (!tmpf) {
+        perror("heredoc");
+        break;
+      }
+    }
+    read_heredoc_input(delimiter, tmpf, delimiter == last_delimiter);
+    delim_node = delim_node->next;
+  }
+  return (tmpf);
 }
 
 // Helper function to handle fallback heredoc (backward compatibility)
-static t_file	*process_fallback_heredoc(char *redirect_heredoc)
-{
-	t_file	*tmpf;
+static t_file *process_fallback_heredoc(char *redirect_heredoc) {
+  t_file *tmpf;
 
-	tmpf = ft_opentmp(ft_openurand(), true);
-	if (!tmpf)
-	{
-		perror("heredoc");
-		return (NULL);
-	}
-	read_heredoc_input(redirect_heredoc, tmpf, true);
-	return (tmpf);
+  tmpf = ft_opentmp(ft_openurand(), true);
+  if (!tmpf) {
+    perror("heredoc");
+    return (NULL);
+  }
+  read_heredoc_input(redirect_heredoc, tmpf, true);
+  return (tmpf);
 }
 
 // New: process here-documents for parsed commands
-void	process_heredocs(t_cmd *cmds, t_list *env)
-{
-	size_t	iteri;
-	t_file	*tmpf;
+void process_heredocs(t_cmd *cmds) {
+  size_t iteri;
+  t_file *tmpf;
 
-	(void)env;
-	iteri = 0;
-	while (cmds[iteri].args)
-	{
-		tmpf = NULL;
-		if (cmds[iteri].heredoc_delimiters)
-		{
-			tmpf = process_heredoc_delimiters(cmds[iteri].heredoc_delimiters);
-		}
-		else if (cmds[iteri].redirect_heredoc)
-		{
-			tmpf = process_fallback_heredoc(cmds[iteri].redirect_heredoc);
-		}
-		if (tmpf)
-		{
-			lseek(tmpf->fd, 0, SEEK_SET);
-			cmds[iteri].fd_infile = tmpf->fd;
-			free(tmpf);
-		}
-		iteri++;
-	}
+  iteri = 0;
+  while (cmds[iteri].args) {
+    tmpf = NULL;
+    if (cmds[iteri].heredoc_delimiters)
+
+      tmpf = process_heredoc_delimiters(cmds[iteri].heredoc_delimiters);
+
+    else if (cmds[iteri].redirect_heredoc)
+
+      tmpf = process_fallback_heredoc(cmds[iteri].redirect_heredoc);
+
+    if (tmpf) {
+      lseek(tmpf->fd, 0, SEEK_SET);
+      cmds[iteri].fd_infile = tmpf->fd;
+      free(tmpf->path);
+      free(tmpf);
+    }
+    iteri++;
+  }
 }

--- a/src/pipex/cmd_path.c
+++ b/src/pipex/cmd_path.c
@@ -12,70 +12,68 @@
 
 #include "pipex.h"
 #include "shared.h"
+#include <unistd.h>
 
-void	ft_free_split(char **split)
-{
-	int	i;
+void ft_free_split(char **split) {
+  int i;
 
-	i = 0;
-	if (!split)
-		return ;
-	while (split[i])
-		free(split[i++]);
-	free(split);
+  i = 0;
+  if (!split)
+    return;
+  while (split[i])
+    free(split[i++]);
+  free(split);
 }
 
-static char	*ft_check_direct_path(char *cmd)
-{
-	if (ft_strchr(cmd, '/'))
-	{
-		if (access(cmd, X_OK) == 0)
-			return (ft_strdup(cmd));
-		return (NULL);
-	}
-	return (NULL);
+static char *ft_check_direct_path(char *cmd) {
+  if (ft_strchr(cmd, '/')) {
+    if (access(cmd, X_OK) == 0)
+      return (ft_strdup(cmd));
+    return (NULL);
+  }
+  return (NULL);
 }
 
-char	*ft_get_cmd_path(char *cmd, t_list *tenvp)
-{
-	t_path_data	pd;
-	char		**freeleak;
+char *ft_get_cmd_path(char *cmd, t_list *tenvp) {
+  t_path_data pd;
+  char **freeleak;
 
-	pd.full_path = NULL;
-	freeleak = b_getenv("PATH", tenvp);
-	pd.paths = ft_split(*freeleak, ':');
-	free(*freeleak);
-	free(freeleak);
-	pd.full_path = ft_check_direct_path(cmd);
-	if (pd.full_path)
-		return (pd.full_path);
-	pd.i = 0;
-	while (pd.paths && pd.paths[pd.i])
-	{
-		pd.tmp = ft_strjoin(pd.paths[pd.i], "/");
-		pd.full_path = ft_strjoin(pd.tmp, cmd);
-		free(pd.tmp);
-		if (access(pd.full_path, X_OK) == 0)
-			break ;
-		free(pd.full_path);
-		pd.full_path = NULL;
-		pd.i++;
-	}
-	ft_free_split(pd.paths);
-	return (pd.full_path);
+  pd.full_path = NULL;
+  freeleak = b_getenv("PATH", tenvp);
+  if (freeleak == NULL)
+    return (NULL);
+  pd.paths = ft_split(*freeleak, ':');
+  free(*freeleak);
+  free(freeleak);
+  pd.full_path = ft_check_direct_path(cmd);
+  if (pd.full_path)
+    return (pd.full_path);
+  pd.i = 0;
+  while (pd.paths && pd.paths[pd.i]) {
+    pd.tmp = ft_strjoin(pd.paths[pd.i], "/");
+    pd.full_path = ft_strjoin(pd.tmp, cmd);
+    free(pd.tmp);
+    if (access(pd.full_path, X_OK) == 0)
+      break;
+    free(pd.full_path);
+    pd.full_path = NULL;
+    pd.i++;
+  }
+  ft_free_split(pd.paths);
+  return (pd.full_path);
 }
 
 /*
 int	main(int ac, char **av, char **envp)
 {
-	char	*argv[] = {"./pipex", "infile", "ls", "-l", NULL};
-	int		k;
-	char	*s;
+        char	*argv[] = {"./pipex", "infile", "ls", "-l", NULL};
+        int		k;
+        char	*s;
 
-	k = 0;
-	s = ft_get_cmd_path(argv[2], envp);
-	ft_printf("%s\n", s);
-	free(s);
-	return (0);
+        k = 0;
+        s = ft_get_cmd_path(argv[2], envp);
+        ft_printf("%s\n", s);
+        free(s);
+        return (0);
 }
 */

--- a/src/pipex/ft_builtin.c
+++ b/src/pipex/ft_builtin.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/07 09:38:39 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/21 15:56:51 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/23 11:52:39 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	is_builtin(t_cmd **cmd, t_list **env, int cmd_idx, t_reader *exit)
 	else if (!ft_strncmp((*cmd)[cmd_idx].args[0], "export", 7))
 		ft_export((*cmd)[cmd_idx].args, env);
 	else if (!ft_strncmp((*cmd)[cmd_idx].args[0], "pwd", 4))
-		ft_pwd(env);
+		ft_pwd();
 	else if (!ft_strncmp((*cmd)[cmd_idx].args[0], "unset", 6))
 		ft_unset((*cmd)[cmd_idx].args, env);
 	else if (!ft_strncmp((*cmd)[cmd_idx].args[0], "exit", 5))

--- a/src/pipex/ft_pipex.c
+++ b/src/pipex/ft_pipex.c
@@ -18,113 +18,101 @@
 #include "utils.h"
 #include <sys/wait.h>
 
-static void	pipe_redirection(t_cmd *cmd, int cmd_idx)
-{
-	if (cmd[cmd_idx].fd_infile != STDIN_FILENO)
-		dup2(cmd[cmd_idx].fd_infile, STDIN_FILENO);
-	else if (cmd_idx > 0)
-		dup2(cmd->pipes[cmd_idx - 1][0], STDIN_FILENO);
-	if (cmd[cmd_idx].fd_outfile != STDOUT_FILENO)
-		dup2(cmd[cmd_idx].fd_outfile, STDOUT_FILENO);
-	else if (cmd_idx < cmd->cmdnbr - 1)
-		dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
-	closefd(cmd, NO_EXIT, NULL);
+static void pipe_redirection(t_cmd *cmd, int cmd_idx) {
+  if (cmd[cmd_idx].fd_infile != STDIN_FILENO)
+    dup2(cmd[cmd_idx].fd_infile, STDIN_FILENO);
+  else if (cmd_idx > 0)
+    dup2(cmd->pipes[cmd_idx - 1][0], STDIN_FILENO);
+  if (cmd[cmd_idx].fd_outfile != STDOUT_FILENO)
+    dup2(cmd[cmd_idx].fd_outfile, STDOUT_FILENO);
+  else if (cmd_idx < cmd->cmdnbr - 1)
+    dup2(cmd->pipes[cmd_idx][1], STDOUT_FILENO);
+  closefd(cmd, NO_EXIT, NULL);
 }
 
-static void	fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx, t_reader *exit)
-{
-	cmd[cmd_idx].pid = fork();
-	if (cmd[cmd_idx].pid == -1)
-	{
-		printf("error fork of pid %d", cmd_idx);
-		closefd(cmd, EXIT_FAILURE, exit);
-	}
-	if (cmd[cmd_idx].pid == 0)
-	{
-		pipe_redirection(cmd, cmd_idx);
-		if (ft_check_if_builtin(cmd, cmd_idx))
-			is_builtin(&cmd, &tenvp, cmd_idx, exit);
-		if (cmd->error == 1)
-			closefd(cmd, EXIT_FAILURE, exit);
-		if (!cmd->cmdpathlist[cmd_idx])
-			closefd(cmd, 127, exit);
-		execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL,
-				tenvp));
-		perror(cmd[cmd_idx].args[0]);
-		closefd(cmd, EXIT_FAILURE, exit);
-	}
+static void fd_child(t_cmd *cmd, t_list *tenvp, int cmd_idx, t_reader *exit) {
+  cmd[cmd_idx].pid = fork();
+  if (cmd[cmd_idx].pid == -1) {
+    printf("error fork of pid %d", cmd_idx);
+    closefd(cmd, EXIT_FAILURE, exit);
+  }
+  if (cmd[cmd_idx].pid == 0) {
+    pipe_redirection(cmd, cmd_idx);
+    if (ft_check_if_builtin(cmd, cmd_idx))
+      is_builtin(&cmd, &tenvp, cmd_idx, exit);
+    if (cmd->error == 1)
+      closefd(cmd, EXIT_FAILURE, exit);
+    if (!cmd->cmdpathlist[cmd_idx])
+      closefd(cmd, 127, exit);
+    execve(cmd->cmdpathlist[cmd_idx], cmd[cmd_idx].args, b_getenv(NULL, tenvp));
+    perror(cmd[cmd_idx].args[0]);
+    closefd(cmd, EXIT_FAILURE, exit);
+  }
 }
 
-void	ft_wait_for_children(int last_pid)
-{
-	int		status;
-	int		sig;
-	pid_t	wpid;
+void ft_wait_for_children(int last_pid) {
+  int status;
+  int sig;
+  pid_t wpid;
 
-	wpid = waitpid(-1, &status, WNOHANG);
-	while (wpid != -1)
-	{
-		if (wpid == last_pid)
-		{
-			if (WIFEXITED(status))
-				g_status_code = WEXITSTATUS(status);
-			else if (WIFSIGNALED(status))
-			{
-				sig = WTERMSIG(status);
-				if (WCOREDUMP(status))
-					ft_putstr_fd(" (core dumped)", 2);
-				ft_putstr_fd("\n", 2);
-				g_status_code = 128 + sig;
-			}
-			else
-				g_status_code = EXIT_FAILURE;
-		}
-		wpid = waitpid(-1, &status, WNOHANG);
-	}
+  wpid = waitpid(-1, &status, WNOHANG);
+  while (wpid != -1) {
+    if (wpid == last_pid) {
+      if (WIFEXITED(status))
+        g_status_code = WEXITSTATUS(status);
+      else if (WIFSIGNALED(status)) {
+        sig = WTERMSIG(status);
+        if (WCOREDUMP(status))
+          ft_putstr_fd(" (core dumped)", 2);
+        ft_putstr_fd("\n", 2);
+        g_status_code = 128 + sig;
+      } else
+        g_status_code = EXIT_FAILURE;
+    }
+    wpid = waitpid(-1, &status, WNOHANG);
+  }
 }
 
 // iter.i, in fd_child indicates the command nbr
 // waitpdid->(cmd[iter.i].pid, ...) and fd_child(cmd, tenvp, iter.i++) teamwork
 // WARNING cmdpathlist does a malloc and contains mallocs
-static void	fd_pipex_execute(t_cmd *cmd, t_list *tenvp, t_reader *exit)
-{
-	t_iteration	iter;
+static void fd_pipex_execute(t_cmd *cmd, t_list *tenvp, t_reader *exit) {
+  t_iteration iter;
 
-	cmd->pipes = malloc(sizeof(int *) * (cmd->cmdnbr - 1));
-	if (!cmd->pipes)
-		return ((void)cmd->error++);
-	iter.i = 0;
-	while (iter.i < cmd->cmdnbr - 1)
-	{
-		cmd->pipes[iter.i] = malloc(sizeof(int) * 2);
-		if (pipe(cmd->pipes[iter.i++]) == -1)
-			return ((void)cmd->error++);
-	}
-	ft_cmdpathlist(cmd, tenvp);
-	iter.i = 0;
-	while (iter.i < cmd->cmdnbr)
-		fd_child(cmd, tenvp, iter.i++, exit);
-	iter.i = 0;
-	while (iter.i < cmd->cmdnbr - 1)
-	{
-		close(cmd->pipes[iter.i][0]);
-		close(cmd->pipes[iter.i++][1]);
-	}
-	ft_wait_for_children(cmd[cmd->cmdnbr - 1].pid);
+  cmd->pipes = malloc(sizeof(int *) * (cmd->cmdnbr - 1));
+  if (!cmd->pipes)
+    return ((void)cmd->error++);
+  iter.i = 0;
+  while (iter.i < cmd->cmdnbr - 1) {
+    cmd->pipes[iter.i] = malloc(sizeof(int) * 2);
+    if (pipe(cmd->pipes[iter.i++]) == -1)
+      return ((void)cmd->error++);
+  }
+  ft_cmdpathlist(cmd, tenvp);
+  iter.i = 0;
+  while (iter.i < cmd->cmdnbr)
+    fd_child(cmd, tenvp, iter.i++, exit);
+  iter.i = 0;
+  while (iter.i < cmd->cmdnbr - 1) {
+    close(cmd->pipes[iter.i][0]);
+    close(cmd->pipes[iter.i++][1]);
+  }
+  ft_wait_for_children(cmd[cmd->cmdnbr - 1].pid);
 }
 
-void ft_pipex(t_cmd *cmd, t_list *tenvp, t_reader *exit)
-{
-	cmd->error = 0;
-	cmd->cmdnbr = ft_nbrofcmds(cmd);
-	cmd->stdin_backup = -1;
-	cmd->stdout_backup = -1;
+void ft_pipex(t_cmd *cmd, t_list *tenvp, t_reader *exit) {
+  cmd->error = 0;
+  cmd->cmdnbr = ft_nbrofcmds(cmd);
+  cmd->stdin_backup = -1;
+  cmd->stdout_backup = -1;
 
-	if (cmd->cmdnbr == 1)
-		ft_exec_solobuiltin(cmd, &tenvp, exit);
-	else
-		fd_pipex_execute(cmd, tenvp, exit);
-	if (cmd->error != 0)
-		g_status_code = cmd->error;
-	ft_cleanup_cmd(cmd);
+  if (cmd->cmdnbr != 0) {
+    if (cmd->cmdnbr == 1 && ft_check_if_builtin(cmd, 0))
+      ft_exec_solobuiltin(cmd, &tenvp, exit);
+    else
+      fd_pipex_execute(cmd, tenvp, exit);
+    if (cmd->error != 0)
+      g_status_code = cmd->error;
+  }
+  ft_cleanup_cmd(cmd);
 }

--- a/src/pipex/ft_utils.c
+++ b/src/pipex/ft_utils.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/01 13:34:25 by jfranc            #+#    #+#             */
-/*   Updated: 2025/07/22 16:18:15 by jfranc           ###   ########.fr       */
+/*   Updated: 2025/07/23 11:53:15 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,47 +71,47 @@ int	ft_nbrofcmds(t_cmd *cmd)
 	return (nbr);
 }
 
-static void ft_dispatch_builtin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
+static void	ft_dispatch_builtin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
 {
-    if (!ft_strncmp(cmd->args[0], "exit", 5))
-        ft_exit(cmd->args, exit, NULL);
-    else if (!ft_strncmp(cmd->args[0], "cd", 3))
-        ft_cd(cmd->args, tenvp);
-    else if (!ft_strncmp(cmd->args[0], "export", 7))
-        ft_export(cmd->args, tenvp);
-    else if (!ft_strncmp(cmd->args[0], "unset", 6))
-        ft_unset(cmd->args, tenvp);
-    else if (!ft_strncmp(cmd->args[0], "pwd", 4))
-        ft_pwd(tenvp);
-    else if (!ft_strncmp(cmd->args[0], "env", 4))
-        ft_env(tenvp);
-    else if (!ft_strncmp(cmd->args[0], "echo", 5))
-        ft_echo(cmd->argc, cmd->args);
+	if (!ft_strncmp(cmd->args[0], "exit", 5))
+		ft_exit(cmd->args, exit, NULL);
+	else if (!ft_strncmp(cmd->args[0], "cd", 3))
+		ft_cd(cmd->args, tenvp);
+	else if (!ft_strncmp(cmd->args[0], "export", 7))
+		ft_export(cmd->args, tenvp);
+	else if (!ft_strncmp(cmd->args[0], "unset", 6))
+		ft_unset(cmd->args, tenvp);
+	else if (!ft_strncmp(cmd->args[0], "pwd", 4))
+		ft_pwd();
+	else if (!ft_strncmp(cmd->args[0], "env", 4))
+		ft_env(tenvp);
+	else if (!ft_strncmp(cmd->args[0], "echo", 5))
+		ft_echo(cmd->argc, cmd->args);
 }
 
-void    ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
+void	ft_exec_solobuiltin(t_cmd *cmd, t_list **tenvp, t_reader *exit)
 {
-    if (cmd->fd_infile != STDIN_FILENO)
-    {
-        cmd->stdin_backup = dup(STDIN_FILENO); 
-        if (dup2(cmd->fd_infile, STDIN_FILENO) == -1)
-            perror("dup2 infile");
-    }
-    if (cmd->fd_outfile != STDOUT_FILENO)
-    {   
-        cmd->stdout_backup = dup(STDOUT_FILENO); 
-        if (dup2(cmd->fd_outfile, STDOUT_FILENO) == -1)
-            perror("dup2 outfile");
-    }
-    ft_dispatch_builtin(cmd, tenvp, exit);
-    if (cmd->stdin_backup != -1)
-    {
-        dup2(cmd->stdin_backup, STDIN_FILENO);
-        close(cmd->stdin_backup);
-    }
-    if (cmd->stdout_backup != -1)
-    {
-        dup2(cmd->stdout_backup, STDOUT_FILENO);
-        close(cmd->stdout_backup);
-    }
+	if (cmd->fd_infile != STDIN_FILENO)
+	{
+		cmd->stdin_backup = dup(STDIN_FILENO);
+		if (dup2(cmd->fd_infile, STDIN_FILENO) == -1)
+			perror("dup2 infile");
+	}
+	if (cmd->fd_outfile != STDOUT_FILENO)
+	{
+		cmd->stdout_backup = dup(STDOUT_FILENO);
+		if (dup2(cmd->fd_outfile, STDOUT_FILENO) == -1)
+			perror("dup2 outfile");
+	}
+	ft_dispatch_builtin(cmd, tenvp, exit);
+	if (cmd->stdin_backup != -1)
+	{
+		dup2(cmd->stdin_backup, STDIN_FILENO);
+		close(cmd->stdin_backup);
+	}
+	if (cmd->stdout_backup != -1)
+	{
+		dup2(cmd->stdout_backup, STDOUT_FILENO);
+		close(cmd->stdout_backup);
+	}
 }

--- a/src/process_commands.c
+++ b/src/process_commands.c
@@ -17,16 +17,15 @@
 #include "shared.h"
 #include "utils.h"
 
-void	process_commands(t_reader *reader_ptr)
-{
-	t_list	*varlists;
+void process_commands(t_reader *reader_ptr) {
+  t_list *varlists;
 
-	reader_ptr->commands = parser_to_list(reader_ptr->parser);
-	varlists = reader_ptr->vars;
-	process_variable_expansion(reader_ptr);
-	free_varlists(varlists);
-	if (reader_ptr->commands)
-		process_heredocs(reader_ptr->commands, reader_ptr->env);
-	reader_ptr->commands = remove_empty_commands(reader_ptr->commands);
-	ft_pipex(reader_ptr->commands, reader_ptr->env, reader_ptr);
+  reader_ptr->commands = parser_to_list(reader_ptr->parser);
+  varlists = reader_ptr->vars;
+  process_variable_expansion(reader_ptr);
+  free_varlists(varlists);
+  if (reader_ptr->commands)
+    process_heredocs(reader_ptr->commands);
+  reader_ptr->commands = remove_empty_commands(reader_ptr->commands);
+  ft_pipex(reader_ptr->commands, reader_ptr->env, reader_ptr);
 }

--- a/src/reader/reader_init.c
+++ b/src/reader/reader_init.c
@@ -6,7 +6,7 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 19:42:35 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/22 13:34:49 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/23 11:53:26 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,11 @@ static t_reader	*allocate_reader(void)
 
 static int	initialize_env(t_reader *reader, char *const *envp)
 {
+	if (envp == NULL || *envp == NULL)
+	{
+		reader->env = NULL;
+		return (1);
+	}
 	reader->env = b_fromenvp(envp);
 	if (reader->env == NULL)
 	{

--- a/src/remove_empty_commands.c
+++ b/src/remove_empty_commands.c
@@ -11,46 +11,44 @@
 /* ************************************************************************** */
 
 #include "shared.h"
+#include <stdlib.h>
 
-t_cmd	*copy_valid_commands(t_cmd *commands, t_cmd *new_commands, size_t count,
-		size_t valid_count)
-{
-	size_t	i;
-	size_t	j;
+t_cmd *copy_valid_commands(t_cmd *commands, t_cmd *new_commands, size_t count,
+                           size_t valid_count) {
+  size_t i;
+  size_t j;
 
-	j = 0;
-	i = 0;
-	while (i < count)
-	{
-		if (commands[i].argc > 0)
-			new_commands[j++] = commands[i];
-		i++;
-	}
-	ft_bzero(&new_commands[valid_count], sizeof(t_cmd));
-	new_commands[valid_count].argc = -1;
-	free(commands);
-	return (new_commands);
+  j = 0;
+  i = 0;
+  while (i < count) {
+    if (commands[i].argc > 0)
+      new_commands[j++] = commands[i];
+    i++;
+  }
+  ft_bzero(&new_commands[valid_count], sizeof(t_cmd));
+  new_commands[valid_count].argc = -1;
+  ft_cleanup_cmd(commands);
+  free(commands);
+  return (new_commands);
 }
 
-t_cmd	*remove_empty_commands(t_cmd *commands)
-{
-	size_t	count;
-	size_t	valid_count;
-	t_cmd	*new_commands;
-	t_cmd	*result;
+t_cmd *remove_empty_commands(t_cmd *commands) {
+  size_t count;
+  size_t valid_count;
+  t_cmd *new_commands;
+  t_cmd *result;
 
-	if (!commands)
-		return (NULL);
-	count = 0;
-	valid_count = 0;
-	while (commands[count].args)
-	{
-		if (commands[count++].argc > 0)
-			valid_count++;
-	}
-	new_commands = ft_calloc(valid_count + 1, sizeof(t_cmd));
-	if (!new_commands)
-		return (NULL);
-	result = copy_valid_commands(commands, new_commands, count, valid_count);
-	return (result);
+  if (!commands)
+    return (NULL);
+  count = 0;
+  valid_count = 0;
+  while (commands[count].args) {
+    if (commands[count++].argc > 0)
+      valid_count++;
+  }
+  new_commands = ft_calloc(valid_count + 1, sizeof(t_cmd));
+  if (!new_commands)
+    return (NULL);
+  result = copy_valid_commands(commands, new_commands, count, valid_count);
+  return (result);
 }

--- a/src/utils/b_unsetenv.c
+++ b/src/utils/b_unsetenv.c
@@ -6,12 +6,13 @@
 /*   By: lfiorell@student.42nice.fr <lfiorell>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/05 11:00:00 by lfiorell@st       #+#    #+#             */
-/*   Updated: 2025/07/22 13:41:31 by lfiorell@st      ###   ########.fr       */
+/*   Updated: 2025/07/23 11:53:33 by lfiorell@st      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "shared.h"
 #include <stdlib.h>
+#include <unistd.h>
 
 static int	str_equal(const char *s1, const char *s2)
 {
@@ -71,10 +72,20 @@ void	b_unsetenv(const char *key, void (*del)(void *), t_list **envp)
 {
 	t_list	*current;
 	t_list	*prev;
+		char *cwd;
 
 	if (!key || !envp || !*envp)
 		return ;
-	if (ft_strncmp(key, "PWD", 4) == 0 || ft_strncmp(key, "OLDPWD", 7) == 0)
+	if (ft_strncmp(key, "PWD", 4) == 0)
+	{
+		cwd = getcwd(NULL, 0);
+		if (!cwd)
+			return ;
+		b_setenv(key, cwd, envp);
+		free(cwd);
+		return ;
+	}
+	if (ft_strncmp(key, "OLDPWD", 7) == 0)
 		return (b_setenv(key, getenv(key), envp));
 	current = *envp;
 	prev = NULL;

--- a/src/utils/var/count_unmatched_var.c
+++ b/src/utils/var/count_unmatched_var.c
@@ -18,7 +18,7 @@ size_t	count_unmatched_var(char *str, size_t i)
 	size_t	count;
 
 	count = 1;
-	while (iskey(str[i]))
+	while (str[i] != '\0' && iskey(str[i]))
 	{
 		count++;
 		i++;

--- a/src/utils/var/expand_unmatched_var.c
+++ b/src/utils/var/expand_unmatched_var.c
@@ -16,7 +16,7 @@
 size_t	expand_unmatched_var(char *dest, char *src, size_t i, size_t k)
 {
 	dest[k++] = '$';
-	while (iskey(src[i]))
+	while (src[i] != '\0' && iskey(src[i]))
 	{
 		dest[k++] = src[i++];
 	}

--- a/src/utils/var/handle_dollar_char.c
+++ b/src/utils/var/handle_dollar_char.c
@@ -16,13 +16,15 @@ size_t	handle_dollar_char(char *str, size_t *i, char **varnames,
 		t_list *env)
 {
 	(*i)++;
-	if (iskey(str[*i]))
+	if (str[*i] != '\0' && iskey(str[*i]))
 		return (handle_var_expansion(str, i, varnames, env));
-	else if (str[*i] == '?' || str[*i] == '$')
+	else if (str[*i] != '\0' && (str[*i] == '?' || str[*i] == '$'))
 	{
 		(*i)++;
 		return (handle_special_var(str[*i - 1]));
 	}
-	else
+	else if (str[*i] != '\0')
 		return (handle_regular_char(i));
+	else
+		return (1); // Just the '$' character
 }

--- a/src/utils/var/handle_dollar_substitution.c
+++ b/src/utils/var/handle_dollar_substitution.c
@@ -15,20 +15,25 @@
 size_t	handle_dollar_substitution(t_var_context *ctx)
 {
 	(*ctx->i)++;
-	if (iskey(ctx->src[*ctx->i]))
+	if (ctx->src[*ctx->i] != '\0' && iskey(ctx->src[*ctx->i]))
 		return (handle_var_substitution(ctx));
-	else if (ctx->src[*ctx->i] == '?' || ctx->src[*ctx->i] == '$')
+	else if (ctx->src[*ctx->i] != '\0' && (ctx->src[*ctx->i] == '?' || ctx->src[*ctx->i] == '$'))
 	{
 		ctx->k = expand_special_var(ctx->dest, ctx->src[*ctx->i], ctx->k,
 				ctx->len);
 		(*ctx->i)++;
 		return (ctx->k);
 	}
-	else
+	else if (ctx->src[*ctx->i] != '\0')
 	{
 		ctx->dest[ctx->k++] = '$';
 		ctx->dest[ctx->k++] = ctx->src[*ctx->i];
 		(*ctx->i)++;
+		return (ctx->k);
+	}
+	else
+	{
+		ctx->dest[ctx->k++] = '$';
 		return (ctx->k);
 	}
 }

--- a/src/utils/var/handle_var_expansion.c
+++ b/src/utils/var/handle_var_expansion.c
@@ -31,7 +31,7 @@ size_t	handle_var_expansion(char *str, size_t *i, char **varnames, t_list *env)
 	else
 	{
 		len = count_unmatched_var(str, *i);
-		while (iskey(str[*i]))
+		while (str[*i] != '\0' && iskey(str[*i]))
 			(*i)++;
 		return (len);
 	}

--- a/src/utils/var/handle_var_substitution.c
+++ b/src/utils/var/handle_var_substitution.c
@@ -25,7 +25,7 @@ size_t	handle_var_substitution(t_var_context *ctx)
 	else
 	{
 		ctx->k = expand_unmatched_var(ctx->dest, ctx->src, *ctx->i, ctx->k);
-		while (iskey(ctx->src[*ctx->i]))
+		while (ctx->src[*ctx->i] != '\0' && iskey(ctx->src[*ctx->i]))
 			(*ctx->i)++;
 	}
 	return (ctx->k);


### PR DESCRIPTION
   - Rework the execution logic for built-in commands.
     - Single built-in commands are now executed in the main process, avoiding an unnecessary fork(). This ensures that builtins like cd, export, and unset correctly modify the shell's state.
   - The pwd built-in has been rewritten to use getcwd() instead of relying on the PWD environment variable, making it more robust.
   - The shell now initializes a default environment with PWD and SHLVL if it's started without an environment, improving standalone behavior.
   - Fix multiple out-of-bounds read errors in variable expansion by adding null-terminator checks.
   - Fix memory leaks in process_heredocs and remove_empty_commands.
